### PR TITLE
Discovery Home Assistant Servers

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -25,7 +25,7 @@ if (flutterVersionName == null) {
 android {
     namespace "com.example.hommie"
     compileSdkVersion flutter.compileSdkVersion
-    ndkVersion flutter.ndkVersion
+    ndkVersion "27.0.12077973"//flutter.ndkVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,11 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.PERMISSION_LOCATION" />
+    
+    <!-- Need this permissions for HA server discovery -->
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
+    <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE"/>
 
     <application
         android:label="hommie"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.7.10'
+    ext.kotlin_version = '1.9.0'
     repositories {
         google()
         mavenCentral()

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,6 @@
 org.gradle.jvmargs=-Xmx4G
 android.useAndroidX=true
 android.enableJetifier=true
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -23,7 +23,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "7.3.0" apply false
+    id "com.android.application" version '8.7.2' apply false
 }
 
 include ":app"

--- a/lib/features/auth/application/auth_controller.dart
+++ b/lib/features/auth/application/auth_controller.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/services.dart';
 import 'package:flutter_web_auth_2/flutter_web_auth_2.dart';
-import 'package:hommie/features/auth/auth_provider.dart';
+import 'package:hommie/features/auth/auth_repository_provider.dart';
 import 'package:hommie/features/auth/domain/entities/auth_failure.dart';
 import 'package:hommie/utils/logger.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';

--- a/lib/features/auth/application/servers_discovery_controller.dart
+++ b/lib/features/auth/application/servers_discovery_controller.dart
@@ -8,10 +8,27 @@ part 'servers_discovery_controller.g.dart';
 
 @riverpod
 class ServersDiscoveryController extends _$ServersDiscoveryController {
+  Timer? _timer;
+
   @override
   Future<List<HaServer>> build() async {
+    _startPeriodicDiscovery();
+
     final repository = ref.watch(haServersRepositoryProvider);
 
+    ref.onDispose(() {
+      _timer?.cancel(); // Cancel the timer if it exists
+      _timer = null;
+    });
+
     return repository.getAvailableServers();
+  }
+
+  void _startPeriodicDiscovery() {
+    if (_timer != null) return;
+
+    _timer = Timer.periodic(const Duration(seconds: 10), (_) {
+      ref.invalidateSelf(); // Invalidate and rebuild the controller
+    });
   }
 }

--- a/lib/features/auth/application/servers_discovery_controller.dart
+++ b/lib/features/auth/application/servers_discovery_controller.dart
@@ -12,16 +12,16 @@ class ServersDiscoveryController extends _$ServersDiscoveryController {
 
   @override
   Future<List<HaServer>> build() async {
+    final repository = ref.watch(haServersRepositoryProvider);
+    final servers = await repository.getAvailableServers();
     _startPeriodicDiscovery();
 
-    final repository = ref.watch(haServersRepositoryProvider);
-
     ref.onDispose(() {
-      _timer?.cancel(); // Cancel the timer if it exists
+      _timer?.cancel();
       _timer = null;
     });
 
-    return repository.getAvailableServers();
+    return servers;
   }
 
   void _startPeriodicDiscovery() {

--- a/lib/features/auth/application/servers_discovery_controller.dart
+++ b/lib/features/auth/application/servers_discovery_controller.dart
@@ -1,0 +1,17 @@
+import 'dart:async';
+
+import 'package:hommie/features/auth/domain/entities/ha_server.dart';
+import 'package:hommie/features/auth/ha_servers_repository_provider.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'servers_discovery_controller.g.dart';
+
+@riverpod
+class ServersDiscoveryController extends _$ServersDiscoveryController {
+  @override
+  Future<List<HaServer>> build() async {
+    final repository = ref.watch(haServersRepositoryProvider);
+
+    return repository.getAvailableServers();
+  }
+}

--- a/lib/features/auth/application/servers_discovery_controller.g.dart
+++ b/lib/features/auth/application/servers_discovery_controller.g.dart
@@ -7,7 +7,7 @@ part of 'servers_discovery_controller.dart';
 // **************************************************************************
 
 String _$serversDiscoveryControllerHash() =>
-    r'fe4add52a19dbb6f151f58d6f9aa7a9dae17edad';
+    r'597da0a97661c1bb5f508e30a50b4fddc17d9401';
 
 /// See also [ServersDiscoveryController].
 @ProviderFor(ServersDiscoveryController)

--- a/lib/features/auth/application/servers_discovery_controller.g.dart
+++ b/lib/features/auth/application/servers_discovery_controller.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'servers_discovery_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$serversDiscoveryControllerHash() =>
+    r'fe4add52a19dbb6f151f58d6f9aa7a9dae17edad';
+
+/// See also [ServersDiscoveryController].
+@ProviderFor(ServersDiscoveryController)
+final serversDiscoveryControllerProvider = AutoDisposeAsyncNotifierProvider<
+    ServersDiscoveryController, List<HaServer>>.internal(
+  ServersDiscoveryController.new,
+  name: r'serversDiscoveryControllerProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$serversDiscoveryControllerHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$ServersDiscoveryController = AutoDisposeAsyncNotifier<List<HaServer>>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/auth/auth_repository_provider.dart
+++ b/lib/features/auth/auth_repository_provider.dart
@@ -1,13 +1,14 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:hommie/features/auth/domain/repository/i_auth_repository.dart';
 import 'package:hommie/features/auth/infrastructure/repositories/auth_repository.dart';
 import 'package:hommie/services/networking/secure_credentials_storage.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-part 'auth_provider.g.dart';
+part 'auth_repository_provider.g.dart';
 
 @Riverpod(keepAlive: true)
-AuthRepository authRepository(Ref ref) {
+IAuthRepository authRepository(Ref ref) {
   final securityCredentialStorage =
       SecureCredentialStorage(const FlutterSecureStorage());
   return AuthRepository(securityCredentialStorage);

--- a/lib/features/auth/auth_repository_provider.g.dart
+++ b/lib/features/auth/auth_repository_provider.g.dart
@@ -1,16 +1,16 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'auth_provider.dart';
+part of 'auth_repository_provider.dart';
 
 // **************************************************************************
 // RiverpodGenerator
 // **************************************************************************
 
-String _$authRepositoryHash() => r'a7d0bf4d9c6d2179fc5e5c2a2331e12cae065f2b';
+String _$authRepositoryHash() => r'475c4c5819a7cb83b13f8c841ad0145fc663d638';
 
 /// See also [authRepository].
 @ProviderFor(authRepository)
-final authRepositoryProvider = Provider<AuthRepository>.internal(
+final authRepositoryProvider = Provider<IAuthRepository>.internal(
   authRepository,
   name: r'authRepositoryProvider',
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
@@ -22,6 +22,6 @@ final authRepositoryProvider = Provider<AuthRepository>.internal(
 
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element
-typedef AuthRepositoryRef = ProviderRef<AuthRepository>;
+typedef AuthRepositoryRef = ProviderRef<IAuthRepository>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/auth/domain/entities/ha_server.dart
+++ b/lib/features/auth/domain/entities/ha_server.dart
@@ -1,11 +1,16 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:hommie/features/auth/domain/entities/ha_version.dart';
 
 part 'ha_server.freezed.dart';
 
 @freezed
 class HaServer with _$HaServer {
   factory HaServer({
+    String? uuid,
     required String name,
     required Uri uri,
+    required HaVersion version,
+    Uri? internalUrl,
+    Uri? externalUrl,
   }) = _HaServer;
 }

--- a/lib/features/auth/domain/entities/ha_server.dart
+++ b/lib/features/auth/domain/entities/ha_server.dart
@@ -1,0 +1,11 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'ha_server.freezed.dart';
+
+@freezed
+class HaServer with _$HaServer {
+  factory HaServer({
+    required String name,
+    required Uri uri,
+  }) = _HaServer;
+}

--- a/lib/features/auth/domain/entities/ha_server.freezed.dart
+++ b/lib/features/auth/domain/entities/ha_server.freezed.dart
@@ -16,8 +16,12 @@ final _privateConstructorUsedError = UnsupportedError(
 
 /// @nodoc
 mixin _$HaServer {
+  String? get uuid => throw _privateConstructorUsedError;
   String get name => throw _privateConstructorUsedError;
   Uri get uri => throw _privateConstructorUsedError;
+  HaVersion get version => throw _privateConstructorUsedError;
+  Uri? get internalUrl => throw _privateConstructorUsedError;
+  Uri? get externalUrl => throw _privateConstructorUsedError;
 
   /// Create a copy of HaServer
   /// with the given fields replaced by the non-null parameter values.
@@ -31,7 +35,15 @@ abstract class $HaServerCopyWith<$Res> {
   factory $HaServerCopyWith(HaServer value, $Res Function(HaServer) then) =
       _$HaServerCopyWithImpl<$Res, HaServer>;
   @useResult
-  $Res call({String name, Uri uri});
+  $Res call(
+      {String? uuid,
+      String name,
+      Uri uri,
+      HaVersion version,
+      Uri? internalUrl,
+      Uri? externalUrl});
+
+  $HaVersionCopyWith<$Res> get version;
 }
 
 /// @nodoc
@@ -49,10 +61,18 @@ class _$HaServerCopyWithImpl<$Res, $Val extends HaServer>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
+    Object? uuid = freezed,
     Object? name = null,
     Object? uri = null,
+    Object? version = null,
+    Object? internalUrl = freezed,
+    Object? externalUrl = freezed,
   }) {
     return _then(_value.copyWith(
+      uuid: freezed == uuid
+          ? _value.uuid
+          : uuid // ignore: cast_nullable_to_non_nullable
+              as String?,
       name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
@@ -61,7 +81,29 @@ class _$HaServerCopyWithImpl<$Res, $Val extends HaServer>
           ? _value.uri
           : uri // ignore: cast_nullable_to_non_nullable
               as Uri,
+      version: null == version
+          ? _value.version
+          : version // ignore: cast_nullable_to_non_nullable
+              as HaVersion,
+      internalUrl: freezed == internalUrl
+          ? _value.internalUrl
+          : internalUrl // ignore: cast_nullable_to_non_nullable
+              as Uri?,
+      externalUrl: freezed == externalUrl
+          ? _value.externalUrl
+          : externalUrl // ignore: cast_nullable_to_non_nullable
+              as Uri?,
     ) as $Val);
+  }
+
+  /// Create a copy of HaServer
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $HaVersionCopyWith<$Res> get version {
+    return $HaVersionCopyWith<$Res>(_value.version, (value) {
+      return _then(_value.copyWith(version: value) as $Val);
+    });
   }
 }
 
@@ -73,7 +115,16 @@ abstract class _$$HaServerImplCopyWith<$Res>
       __$$HaServerImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({String name, Uri uri});
+  $Res call(
+      {String? uuid,
+      String name,
+      Uri uri,
+      HaVersion version,
+      Uri? internalUrl,
+      Uri? externalUrl});
+
+  @override
+  $HaVersionCopyWith<$Res> get version;
 }
 
 /// @nodoc
@@ -89,10 +140,18 @@ class __$$HaServerImplCopyWithImpl<$Res>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
+    Object? uuid = freezed,
     Object? name = null,
     Object? uri = null,
+    Object? version = null,
+    Object? internalUrl = freezed,
+    Object? externalUrl = freezed,
   }) {
     return _then(_$HaServerImpl(
+      uuid: freezed == uuid
+          ? _value.uuid
+          : uuid // ignore: cast_nullable_to_non_nullable
+              as String?,
       name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
@@ -101,6 +160,18 @@ class __$$HaServerImplCopyWithImpl<$Res>
           ? _value.uri
           : uri // ignore: cast_nullable_to_non_nullable
               as Uri,
+      version: null == version
+          ? _value.version
+          : version // ignore: cast_nullable_to_non_nullable
+              as HaVersion,
+      internalUrl: freezed == internalUrl
+          ? _value.internalUrl
+          : internalUrl // ignore: cast_nullable_to_non_nullable
+              as Uri?,
+      externalUrl: freezed == externalUrl
+          ? _value.externalUrl
+          : externalUrl // ignore: cast_nullable_to_non_nullable
+              as Uri?,
     ));
   }
 }
@@ -108,16 +179,30 @@ class __$$HaServerImplCopyWithImpl<$Res>
 /// @nodoc
 
 class _$HaServerImpl implements _HaServer {
-  _$HaServerImpl({required this.name, required this.uri});
+  _$HaServerImpl(
+      {this.uuid,
+      required this.name,
+      required this.uri,
+      required this.version,
+      this.internalUrl,
+      this.externalUrl});
 
+  @override
+  final String? uuid;
   @override
   final String name;
   @override
   final Uri uri;
+  @override
+  final HaVersion version;
+  @override
+  final Uri? internalUrl;
+  @override
+  final Uri? externalUrl;
 
   @override
   String toString() {
-    return 'HaServer(name: $name, uri: $uri)';
+    return 'HaServer(uuid: $uuid, name: $name, uri: $uri, version: $version, internalUrl: $internalUrl, externalUrl: $externalUrl)';
   }
 
   @override
@@ -125,12 +210,19 @@ class _$HaServerImpl implements _HaServer {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$HaServerImpl &&
+            (identical(other.uuid, uuid) || other.uuid == uuid) &&
             (identical(other.name, name) || other.name == name) &&
-            (identical(other.uri, uri) || other.uri == uri));
+            (identical(other.uri, uri) || other.uri == uri) &&
+            (identical(other.version, version) || other.version == version) &&
+            (identical(other.internalUrl, internalUrl) ||
+                other.internalUrl == internalUrl) &&
+            (identical(other.externalUrl, externalUrl) ||
+                other.externalUrl == externalUrl));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, name, uri);
+  int get hashCode => Object.hash(
+      runtimeType, uuid, name, uri, version, internalUrl, externalUrl);
 
   /// Create a copy of HaServer
   /// with the given fields replaced by the non-null parameter values.
@@ -142,13 +234,26 @@ class _$HaServerImpl implements _HaServer {
 }
 
 abstract class _HaServer implements HaServer {
-  factory _HaServer({required final String name, required final Uri uri}) =
-      _$HaServerImpl;
+  factory _HaServer(
+      {final String? uuid,
+      required final String name,
+      required final Uri uri,
+      required final HaVersion version,
+      final Uri? internalUrl,
+      final Uri? externalUrl}) = _$HaServerImpl;
 
+  @override
+  String? get uuid;
   @override
   String get name;
   @override
   Uri get uri;
+  @override
+  HaVersion get version;
+  @override
+  Uri? get internalUrl;
+  @override
+  Uri? get externalUrl;
 
   /// Create a copy of HaServer
   /// with the given fields replaced by the non-null parameter values.

--- a/lib/features/auth/domain/entities/ha_server.freezed.dart
+++ b/lib/features/auth/domain/entities/ha_server.freezed.dart
@@ -1,0 +1,159 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'ha_server.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$HaServer {
+  String get name => throw _privateConstructorUsedError;
+  Uri get uri => throw _privateConstructorUsedError;
+
+  /// Create a copy of HaServer
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $HaServerCopyWith<HaServer> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $HaServerCopyWith<$Res> {
+  factory $HaServerCopyWith(HaServer value, $Res Function(HaServer) then) =
+      _$HaServerCopyWithImpl<$Res, HaServer>;
+  @useResult
+  $Res call({String name, Uri uri});
+}
+
+/// @nodoc
+class _$HaServerCopyWithImpl<$Res, $Val extends HaServer>
+    implements $HaServerCopyWith<$Res> {
+  _$HaServerCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of HaServer
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? name = null,
+    Object? uri = null,
+  }) {
+    return _then(_value.copyWith(
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      uri: null == uri
+          ? _value.uri
+          : uri // ignore: cast_nullable_to_non_nullable
+              as Uri,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$HaServerImplCopyWith<$Res>
+    implements $HaServerCopyWith<$Res> {
+  factory _$$HaServerImplCopyWith(
+          _$HaServerImpl value, $Res Function(_$HaServerImpl) then) =
+      __$$HaServerImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String name, Uri uri});
+}
+
+/// @nodoc
+class __$$HaServerImplCopyWithImpl<$Res>
+    extends _$HaServerCopyWithImpl<$Res, _$HaServerImpl>
+    implements _$$HaServerImplCopyWith<$Res> {
+  __$$HaServerImplCopyWithImpl(
+      _$HaServerImpl _value, $Res Function(_$HaServerImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of HaServer
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? name = null,
+    Object? uri = null,
+  }) {
+    return _then(_$HaServerImpl(
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      uri: null == uri
+          ? _value.uri
+          : uri // ignore: cast_nullable_to_non_nullable
+              as Uri,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$HaServerImpl implements _HaServer {
+  _$HaServerImpl({required this.name, required this.uri});
+
+  @override
+  final String name;
+  @override
+  final Uri uri;
+
+  @override
+  String toString() {
+    return 'HaServer(name: $name, uri: $uri)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$HaServerImpl &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.uri, uri) || other.uri == uri));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, name, uri);
+
+  /// Create a copy of HaServer
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$HaServerImplCopyWith<_$HaServerImpl> get copyWith =>
+      __$$HaServerImplCopyWithImpl<_$HaServerImpl>(this, _$identity);
+}
+
+abstract class _HaServer implements HaServer {
+  factory _HaServer({required final String name, required final Uri uri}) =
+      _$HaServerImpl;
+
+  @override
+  String get name;
+  @override
+  Uri get uri;
+
+  /// Create a copy of HaServer
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$HaServerImplCopyWith<_$HaServerImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/features/auth/domain/entities/ha_version.dart
+++ b/lib/features/auth/domain/entities/ha_version.dart
@@ -1,0 +1,32 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'ha_version.freezed.dart';
+
+@freezed
+class HaVersion with _$HaVersion {
+  factory HaVersion({
+    required int major,
+    required int minor,
+    int? patch,
+  }) = _HaVersion;
+
+  factory HaVersion.fromString(String strVersion) {
+    final parts = strVersion.split('.');
+
+    if (parts.length < 2 || parts.length > 3) {
+      throw FormatException('Invalid version format: $strVersion');
+    }
+
+    final major = int.tryParse(parts[0]);
+    final minor = int.tryParse(parts[1]);
+    final patch = parts.length == 3 ? int.tryParse(parts[2]) : null;
+
+    if (major == null ||
+        minor == null ||
+        (parts.length == 3 && patch == null)) {
+      throw FormatException('Invalid version numbers: $strVersion');
+    }
+
+    return HaVersion(major: major, minor: minor, patch: patch);
+  }
+}

--- a/lib/features/auth/domain/entities/ha_version.freezed.dart
+++ b/lib/features/auth/domain/entities/ha_version.freezed.dart
@@ -1,0 +1,177 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'ha_version.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$HaVersion {
+  int get major => throw _privateConstructorUsedError;
+  int get minor => throw _privateConstructorUsedError;
+  int? get patch => throw _privateConstructorUsedError;
+
+  /// Create a copy of HaVersion
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $HaVersionCopyWith<HaVersion> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $HaVersionCopyWith<$Res> {
+  factory $HaVersionCopyWith(HaVersion value, $Res Function(HaVersion) then) =
+      _$HaVersionCopyWithImpl<$Res, HaVersion>;
+  @useResult
+  $Res call({int major, int minor, int? patch});
+}
+
+/// @nodoc
+class _$HaVersionCopyWithImpl<$Res, $Val extends HaVersion>
+    implements $HaVersionCopyWith<$Res> {
+  _$HaVersionCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of HaVersion
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? major = null,
+    Object? minor = null,
+    Object? patch = freezed,
+  }) {
+    return _then(_value.copyWith(
+      major: null == major
+          ? _value.major
+          : major // ignore: cast_nullable_to_non_nullable
+              as int,
+      minor: null == minor
+          ? _value.minor
+          : minor // ignore: cast_nullable_to_non_nullable
+              as int,
+      patch: freezed == patch
+          ? _value.patch
+          : patch // ignore: cast_nullable_to_non_nullable
+              as int?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$HaVersionImplCopyWith<$Res>
+    implements $HaVersionCopyWith<$Res> {
+  factory _$$HaVersionImplCopyWith(
+          _$HaVersionImpl value, $Res Function(_$HaVersionImpl) then) =
+      __$$HaVersionImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({int major, int minor, int? patch});
+}
+
+/// @nodoc
+class __$$HaVersionImplCopyWithImpl<$Res>
+    extends _$HaVersionCopyWithImpl<$Res, _$HaVersionImpl>
+    implements _$$HaVersionImplCopyWith<$Res> {
+  __$$HaVersionImplCopyWithImpl(
+      _$HaVersionImpl _value, $Res Function(_$HaVersionImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of HaVersion
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? major = null,
+    Object? minor = null,
+    Object? patch = freezed,
+  }) {
+    return _then(_$HaVersionImpl(
+      major: null == major
+          ? _value.major
+          : major // ignore: cast_nullable_to_non_nullable
+              as int,
+      minor: null == minor
+          ? _value.minor
+          : minor // ignore: cast_nullable_to_non_nullable
+              as int,
+      patch: freezed == patch
+          ? _value.patch
+          : patch // ignore: cast_nullable_to_non_nullable
+              as int?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$HaVersionImpl implements _HaVersion {
+  _$HaVersionImpl({required this.major, required this.minor, this.patch});
+
+  @override
+  final int major;
+  @override
+  final int minor;
+  @override
+  final int? patch;
+
+  @override
+  String toString() {
+    return 'HaVersion(major: $major, minor: $minor, patch: $patch)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$HaVersionImpl &&
+            (identical(other.major, major) || other.major == major) &&
+            (identical(other.minor, minor) || other.minor == minor) &&
+            (identical(other.patch, patch) || other.patch == patch));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, major, minor, patch);
+
+  /// Create a copy of HaVersion
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$HaVersionImplCopyWith<_$HaVersionImpl> get copyWith =>
+      __$$HaVersionImplCopyWithImpl<_$HaVersionImpl>(this, _$identity);
+}
+
+abstract class _HaVersion implements HaVersion {
+  factory _HaVersion(
+      {required final int major,
+      required final int minor,
+      final int? patch}) = _$HaVersionImpl;
+
+  @override
+  int get major;
+  @override
+  int get minor;
+  @override
+  int? get patch;
+
+  /// Create a copy of HaVersion
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$HaVersionImplCopyWith<_$HaVersionImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/features/auth/domain/repository/i_auth_repository.dart
+++ b/lib/features/auth/domain/repository/i_auth_repository.dart
@@ -2,7 +2,7 @@ import 'package:fpdart/fpdart.dart';
 import 'package:hommie/features/auth/domain/entities/auth_failure.dart';
 import 'package:oauth2/oauth2.dart';
 
-typedef Future<Map<String, String>> AuthResponseHandler(Uri uri);
+typedef AuthResponseHandler = Future<Map<String, String>> Function(Uri uri);
 
 abstract class IAuthRepository {
   Future<Either<AuthFailure, Credentials>> login(

--- a/lib/features/auth/domain/repository/i_ha_servers_repository.dart
+++ b/lib/features/auth/domain/repository/i_ha_servers_repository.dart
@@ -1,0 +1,5 @@
+import 'package:hommie/features/auth/domain/entities/ha_server.dart';
+
+abstract class IHAServersRepository {
+  Future<List<HaServer>> getAvailableServers();
+}

--- a/lib/features/auth/ha_servers_repository_provider.dart
+++ b/lib/features/auth/ha_servers_repository_provider.dart
@@ -1,0 +1,11 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hommie/features/auth/domain/repository/i_ha_servers_repository.dart';
+import 'package:hommie/features/auth/infrastructure/repositories/ha_servers_repository.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'ha_servers_repository_provider.g.dart';
+
+@riverpod
+IHAServersRepository haServersRepository(Ref ref) {
+  return HAServersRepository();
+}

--- a/lib/features/auth/ha_servers_repository_provider.g.dart
+++ b/lib/features/auth/ha_servers_repository_provider.g.dart
@@ -1,0 +1,29 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'ha_servers_repository_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$haServersRepositoryHash() =>
+    r'815002ea66628d8e41de2709cf8bee820c7b00cb';
+
+/// See also [haServersRepository].
+@ProviderFor(haServersRepository)
+final haServersRepositoryProvider =
+    AutoDisposeProvider<IHAServersRepository>.internal(
+  haServersRepository,
+  name: r'haServersRepositoryProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$haServersRepositoryHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef HaServersRepositoryRef = AutoDisposeProviderRef<IHAServersRepository>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/auth/infrastructure/repositories/ha_servers_repository.dart
+++ b/lib/features/auth/infrastructure/repositories/ha_servers_repository.dart
@@ -29,7 +29,7 @@ class HAServersRepository implements IHAServersRepository {
     try {
       await Future.any([
         _performDiscovery(client, results),
-        Future.delayed(Duration(seconds: 10),
+        Future.delayed(Duration(seconds: 30),
             () => throw TimeoutException("Discovery timed out")),
       ]);
     } catch (e, _) {

--- a/lib/features/auth/infrastructure/repositories/ha_servers_repository.dart
+++ b/lib/features/auth/infrastructure/repositories/ha_servers_repository.dart
@@ -6,7 +6,7 @@ import 'package:hommie/utils/logger.dart';
 import 'package:multicast_dns/multicast_dns.dart';
 
 class HAServersRepository implements IHAServersRepository {
-  static const String _serviceName = '_home-assistant._tcp.local';
+  static const String _serviceName = '_home-assistant._tcp';
 
   @override
   Future<List<HaServer>> getAvailableServers() async {

--- a/lib/features/auth/infrastructure/repositories/ha_servers_repository.dart
+++ b/lib/features/auth/infrastructure/repositories/ha_servers_repository.dart
@@ -6,43 +6,80 @@ import 'package:hommie/utils/logger.dart';
 import 'package:multicast_dns/multicast_dns.dart';
 
 class HAServersRepository implements IHAServersRepository {
+  static const String _serviceName = '_home-assistant._tcp.local';
+
   @override
   Future<List<HaServer>> getAvailableServers() async {
-    const serviceName = '_home-assistant._tcp.local';
     final client = MDnsClient();
     final results = <HaServer>{};
 
     await client.start();
 
     try {
-      await for (final ptr in client.lookup<PtrResourceRecord>(
-          ResourceRecordQuery.serverPointer(serviceName))) {
-        await for (final srv in client.lookup<SrvResourceRecord>(
-            ResourceRecordQuery.service(ptr.domainName))) {
-          final target = srv.target;
-
-          await for (final ip in client.lookup<IPAddressResourceRecord>(
-              ResourceRecordQuery.addressIPv4(target))) {
-            final serverName =
-                ptr.domainName.split('.').first; // Extract server name
-
-            final server = HaServer(
-              name: serverName,
-              uri: Uri.http('${ip.address.address}:${srv.port}'),
-            );
-
-            logger.i(
-              'HomeAssistant instance found at ${server.uri} for "$serverName".',
-            );
-
-            results.add(server);
-          }
-        }
-      }
+      await _discoverWithTimeout(client, results);
     } finally {
       client.stop();
     }
 
     return results.toList();
+  }
+
+  Future<void> _discoverWithTimeout(
+      MDnsClient client, Set<HaServer> results) async {
+    try {
+      await Future.any([
+        _performDiscovery(client, results),
+        Future.delayed(Duration(seconds: 10),
+            () => throw TimeoutException("Discovery timed out")),
+      ]);
+    } catch (e, _) {
+      logger.e("Error during discovery: $e");
+      rethrow; // Re-throw to propagate the error if needed
+    }
+  }
+
+  Future<void> _performDiscovery(
+      MDnsClient client, Set<HaServer> results) async {
+    await for (final ptr in _lookupPtrRecords(client)) {
+      await for (final srv in _lookupSrvRecords(client, ptr)) {
+        await _lookupIpRecords(client, srv, ptr, results);
+      }
+    }
+  }
+
+  Stream<PtrResourceRecord> _lookupPtrRecords(MDnsClient client) {
+    return client.lookup<PtrResourceRecord>(
+      ResourceRecordQuery.serverPointer(_serviceName),
+    );
+  }
+
+  Stream<SrvResourceRecord> _lookupSrvRecords(
+      MDnsClient client, PtrResourceRecord ptr) {
+    return client.lookup<SrvResourceRecord>(
+      ResourceRecordQuery.service(ptr.domainName),
+    );
+  }
+
+  Future<void> _lookupIpRecords(
+    MDnsClient client,
+    SrvResourceRecord srv,
+    PtrResourceRecord ptr,
+    Set<HaServer> results,
+  ) async {
+    await for (final ip in client.lookup<IPAddressResourceRecord>(
+        ResourceRecordQuery.addressIPv4(srv.target))) {
+      final serverName = ptr.domainName.split('.').first;
+
+      final server = HaServer(
+        name: serverName,
+        uri: Uri.http('${ip.address.address}:${srv.port}'),
+      );
+
+      logger.i(
+        'HomeAssistant instance found at ${server.uri} for "$serverName".',
+      );
+
+      results.add(server);
+    }
   }
 }

--- a/lib/features/auth/infrastructure/repositories/ha_servers_repository.dart
+++ b/lib/features/auth/infrastructure/repositories/ha_servers_repository.dart
@@ -1,0 +1,48 @@
+import 'dart:async';
+
+import 'package:hommie/features/auth/domain/entities/ha_server.dart';
+import 'package:hommie/features/auth/domain/repository/i_ha_servers_repository.dart';
+import 'package:hommie/utils/logger.dart';
+import 'package:multicast_dns/multicast_dns.dart';
+
+class HAServersRepository implements IHAServersRepository {
+  @override
+  Future<List<HaServer>> getAvailableServers() async {
+    const serviceName = '_home-assistant._tcp.local';
+    final client = MDnsClient();
+    final results = <HaServer>{};
+
+    await client.start();
+
+    try {
+      await for (final ptr in client.lookup<PtrResourceRecord>(
+          ResourceRecordQuery.serverPointer(serviceName))) {
+        await for (final srv in client.lookup<SrvResourceRecord>(
+            ResourceRecordQuery.service(ptr.domainName))) {
+          final target = srv.target;
+
+          await for (final ip in client.lookup<IPAddressResourceRecord>(
+              ResourceRecordQuery.addressIPv4(target))) {
+            final serverName =
+                ptr.domainName.split('.').first; // Extract server name
+
+            final server = HaServer(
+              name: serverName,
+              uri: Uri.http('${ip.address.address}:${srv.port}'),
+            );
+
+            logger.i(
+              'HomeAssistant instance found at ${server.uri} for "$serverName".',
+            );
+
+            results.add(server);
+          }
+        }
+      }
+    } finally {
+      client.stop();
+    }
+
+    return results.toList();
+  }
+}

--- a/lib/features/auth/presentation/screens/discovery_servers_page.dart
+++ b/lib/features/auth/presentation/screens/discovery_servers_page.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:hommie/features/auth/application/auth_controller.dart';
+import 'package:hommie/features/auth/application/servers_discovery_controller.dart';
+import 'package:hommie/router/routes.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class DiscoveryServersPage extends HookConsumerWidget {
+  const DiscoveryServersPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final discoveredServers = ref.watch(serversDiscoveryControllerProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text("Discover Servers")),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const SizedBox(height: 16),
+            Expanded(
+              child: discoveredServers.when(
+                data: (servers) {
+                  if (servers.isEmpty) {
+                    return Center(
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          const Text("No servers found."),
+                          const SizedBox(height: 16),
+                          ElevatedButton(
+                            onPressed: () {
+                              ref.refresh(
+                                  serversDiscoveryControllerProvider.future);
+                            },
+                            child: const Text("Refresh"),
+                          ),
+                        ],
+                      ),
+                    );
+                  }
+                  return ListView.builder(
+                    itemCount: servers.length,
+                    itemBuilder: (context, index) {
+                      return ListTile(
+                        title: Text(servers[index].name),
+                        subtitle: Text(servers[index].uri.toString()),
+                        trailing: Icon(Icons.chevron_right),
+                        onTap: () {
+                          ref
+                              .read(authControllerProvider.notifier)
+                              .login(servers[index].uri.toString());
+                        },
+                      );
+                    },
+                  );
+                },
+                loading: () => const Center(child: CircularProgressIndicator()),
+                error: (e, stack) =>
+                    const Center(child: Text("Error discovering servers.")),
+              ),
+            ),
+            const SizedBox(height: 16),
+            FilledButton.tonal(
+              onPressed: () => {const EnterAddressRoute().push(context)},
+              child: const Text("Enter Manually"),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/auth/presentation/screens/enter_address_page.dart
+++ b/lib/features/auth/presentation/screens/enter_address_page.dart
@@ -1,18 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hommie/features/auth/application/auth_controller.dart';
-import 'package:hommie/ui/styles/spacings.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-class LoginPage extends HookConsumerWidget {
-  const LoginPage({super.key});
+class EnterAddressPage extends HookConsumerWidget {
+  const EnterAddressPage({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final haServerURLController =
-        useTextEditingController(text: "http://192.168.0.109:8123");
+        useTextEditingController(text: "http://192.168.0.");
 
     return Scaffold(
+      appBar: AppBar(title: const Text("Enter your hub address")),
       body: Padding(
         padding: EdgeInsets.only(
             bottom: 16,
@@ -23,9 +23,9 @@ class LoginPage extends HookConsumerWidget {
           crossAxisAlignment: CrossAxisAlignment.stretch,
           mainAxisSize: MainAxisSize.max,
           children: [
-            Text('Enter your hub address',
-                style: Theme.of(context).textTheme.headlineMedium),
-            $h64,
+            // Text('Enter your hub address',
+            //     style: Theme.of(context).textTheme.headlineMedium),
+            // $h64,
             TextField(
               controller: haServerURLController,
               decoration: const InputDecoration(

--- a/lib/features/auth/presentation/screens/server_discovery_page.dart
+++ b/lib/features/auth/presentation/screens/server_discovery_page.dart
@@ -65,6 +65,13 @@ class ServerDiscoveryPage extends HookConsumerWidget {
                 ),
               ),
             ),
+            Text(
+              "Not finding your screen?",
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                    color: Theme.of(context).colorScheme.secondary,
+                  ),
+            ),
             const SizedBox(height: 16),
             FilledButton.tonal(
               onPressed: () => {const EnterAddressRoute().push(context)},

--- a/lib/features/auth/presentation/screens/server_discovery_page.dart
+++ b/lib/features/auth/presentation/screens/server_discovery_page.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:hommie/features/auth/application/auth_controller.dart';
 import 'package:hommie/features/auth/application/servers_discovery_controller.dart';
+import 'package:hommie/features/auth/presentation/widgets/w_available_severs_list_title.dart';
 import 'package:hommie/features/auth/presentation/widgets/w_empty_state.dart';
 import 'package:hommie/router/routes.dart';
+import 'package:hommie/ui/styles/spacings.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 class ServerDiscoveryPage extends HookConsumerWidget {
@@ -14,23 +16,16 @@ class ServerDiscoveryPage extends HookConsumerWidget {
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text("Server Discovery"),
-        // toolbarHeight: 112,
+        title: const Text("Servers Discovery"),
         centerTitle: false,
-        actions: [
-          IconButton(
-              icon: const Icon(Icons.refresh_rounded),
-              tooltip: 'Show Snackbar',
-              onPressed: () =>
-                  ref.invalidate(serversDiscoveryControllerProvider))
-        ],
       ),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            const SizedBox(height: 16),
+            AvailableSeversListTitle(),
+            $h16,
             Expanded(
               child: discoveredServers.when(
                 data: (servers) {
@@ -44,15 +39,20 @@ class ServerDiscoveryPage extends HookConsumerWidget {
                   return ListView.builder(
                     itemCount: servers.length,
                     itemBuilder: (context, index) {
-                      return ListTile(
-                        title: Text(servers[index].name),
-                        subtitle: Text(servers[index].uri.toString()),
-                        trailing: Icon(Icons.chevron_right),
-                        onTap: () {
-                          ref
-                              .read(authControllerProvider.notifier)
-                              .login(servers[index].uri.toString());
-                        },
+                      return Column(
+                        children: [
+                          ListTile(
+                            title: Text(servers[index].name),
+                            subtitle: Text(servers[index].uri.toString()),
+                            trailing: Icon(Icons.chevron_right),
+                            onTap: () {
+                              ref
+                                  .read(authControllerProvider.notifier)
+                                  .login(servers[index].uri.toString());
+                            },
+                          ),
+                          Divider(),
+                        ],
                       );
                     },
                   );
@@ -65,7 +65,7 @@ class ServerDiscoveryPage extends HookConsumerWidget {
             const SizedBox(height: 16),
             FilledButton.tonal(
               onPressed: () => {const EnterAddressRoute().push(context)},
-              child: const Text("Enter Manually"),
+              child: const Text("Enter addres manually"),
             ),
           ],
         ),

--- a/lib/features/auth/presentation/screens/server_discovery_page.dart
+++ b/lib/features/auth/presentation/screens/server_discovery_page.dart
@@ -1,18 +1,30 @@
 import 'package:flutter/material.dart';
 import 'package:hommie/features/auth/application/auth_controller.dart';
 import 'package:hommie/features/auth/application/servers_discovery_controller.dart';
+import 'package:hommie/features/auth/presentation/widgets/w_empty_state.dart';
 import 'package:hommie/router/routes.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-class DiscoveryServersPage extends HookConsumerWidget {
-  const DiscoveryServersPage({super.key});
+class ServerDiscoveryPage extends HookConsumerWidget {
+  const ServerDiscoveryPage({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final discoveredServers = ref.watch(serversDiscoveryControllerProvider);
 
     return Scaffold(
-      appBar: AppBar(title: const Text("Discover Servers")),
+      appBar: AppBar(
+        title: const Text("Server Discovery"),
+        // toolbarHeight: 112,
+        centerTitle: false,
+        actions: [
+          IconButton(
+              icon: const Icon(Icons.refresh_rounded),
+              tooltip: 'Show Snackbar',
+              onPressed: () =>
+                  ref.invalidate(serversDiscoveryControllerProvider))
+        ],
+      ),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
         child: Column(
@@ -23,21 +35,10 @@ class DiscoveryServersPage extends HookConsumerWidget {
               child: discoveredServers.when(
                 data: (servers) {
                   if (servers.isEmpty) {
-                    return Center(
-                      child: Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          const Text("No servers found."),
-                          const SizedBox(height: 16),
-                          ElevatedButton(
-                            onPressed: () {
-                              ref.refresh(
-                                  serversDiscoveryControllerProvider.future);
-                            },
-                            child: const Text("Refresh"),
-                          ),
-                        ],
-                      ),
+                    return EmptyState(
+                      text: "No servers found.",
+                      onRefresh: () =>
+                          ref.invalidate(serversDiscoveryControllerProvider),
                     );
                   }
                   return ListView.builder(
@@ -57,7 +58,7 @@ class DiscoveryServersPage extends HookConsumerWidget {
                   );
                 },
                 loading: () => const Center(child: CircularProgressIndicator()),
-                error: (e, stack) =>
+                error: (e, _) =>
                     const Center(child: Text("Error discovering servers.")),
               ),
             ),

--- a/lib/features/auth/presentation/screens/server_discovery_page.dart
+++ b/lib/features/auth/presentation/screens/server_discovery_page.dart
@@ -58,8 +58,11 @@ class ServerDiscoveryPage extends HookConsumerWidget {
                   );
                 },
                 loading: () => const Center(child: CircularProgressIndicator()),
-                error: (e, _) =>
-                    const Center(child: Text("Error discovering servers.")),
+                error: (e, _) => EmptyState(
+                  text: "Error discovering servers.",
+                  onRefresh: () =>
+                      ref.invalidate(serversDiscoveryControllerProvider),
+                ),
               ),
             ),
             const SizedBox(height: 16),

--- a/lib/features/auth/presentation/widgets/w_available_severs_list_title.dart
+++ b/lib/features/auth/presentation/widgets/w_available_severs_list_title.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+class AvailableSeversListTitle extends StatelessWidget {
+  const AvailableSeversListTitle({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text(
+          "Available home assistant servers",
+          style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                color: Theme.of(context).colorScheme.secondary,
+              ),
+        ),
+        CircularProgressIndicator.adaptive()
+      ],
+    );
+  }
+}

--- a/lib/features/auth/presentation/widgets/w_empty_state.dart
+++ b/lib/features/auth/presentation/widgets/w_empty_state.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+class EmptyState extends StatelessWidget {
+  final String text;
+  final VoidCallback onRefresh;
+
+  const EmptyState({
+    super.key,
+    required this.text,
+    required this.onRefresh,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(
+            text,
+            style: Theme.of(context).textTheme.bodyLarge,
+          ),
+          const SizedBox(height: 16),
+          TextButton(
+            onPressed: onRefresh,
+            child: const Text('Refresh'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/router/router.dart
+++ b/lib/router/router.dart
@@ -35,22 +35,32 @@ GoRouter goRouter(Ref ref) {
           "Try to redirect. Router listanable state: ${authStateNotifier.value}");
 
       final currentAuthState = authStateNotifier.value;
-      switch (currentAuthState) {
-        case Autenticated()
-            when (state.matchedLocation == const StartupRoute().location) ||
-                (state.matchedLocation == const LoginRoute().location):
-          return const HomeRouteData().location;
-        case Unauthicated():
-          return const LoginRoute().location;
+      final currentLocation = state.matchedLocation;
 
-        /// FIXME: Make it better. A lot of failures might occured, Need to handle
-        /// propperly each of them. For example: refresh token is invalid, no connections, etc
+      switch (currentAuthState) {
+        case Autenticated():
+          if (currentLocation == const StartupRoute().location ||
+              currentLocation == const EnterAddressRoute().location ||
+              currentLocation == const DicoveryRoute().location) {
+            return const HomeRouteData().location;
+          }
+          return null; // Allow navigation if already authenticated
+        case Unauthicated():
+          if (currentLocation != const DicoveryRoute().location &&
+              currentLocation != const EnterAddressRoute().location) {
+            return const DicoveryRoute().location;
+          }
+          return null; // Stay on Discovery or EnterAddress
         case Failure():
-          return const LoginRoute().location;
+          if (currentLocation != const DicoveryRoute().location &&
+              currentLocation != const EnterAddressRoute().location) {
+            return const DicoveryRoute().location;
+          }
+          return null; // Stay on Discovery or EnterAddress
         case Initial():
-          return null;
+          return null; // No redirection needed during initialization
         default:
-          return null;
+          return null; // Handle any other undefined states gracefully
       }
     },
   );

--- a/lib/router/router.g.dart
+++ b/lib/router/router.g.dart
@@ -6,7 +6,7 @@ part of 'router.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$goRouterHash() => r'23578be885b6b8aa1aade8ade71fd78068808fe5';
+String _$goRouterHash() => r'be0b984cfd5801a7e17f38e0116cad97c8dc797c';
 
 /// See also [goRouter].
 @ProviderFor(goRouter)

--- a/lib/router/routes.dart
+++ b/lib/router/routes.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:hommie/features/auth/presentation/screens/discovery_servers_page.dart';
 import 'package:hommie/features/home/presentation/screens/home_page.dart';
-import 'package:hommie/features/auth/presentation/screens/login_page.dart';
+import 'package:hommie/features/auth/presentation/screens/enter_address_page.dart';
 import 'package:hommie/features/home/presentation/screens/root_page.dart';
 import 'package:hommie/features/settings/presentation/screens/about_page.dart';
 import 'package:hommie/features/settings/presentation/screens/hub_page.dart';
@@ -108,13 +109,23 @@ class HomeRouteData extends GoRouteData {
   }
 }
 
-@TypedGoRoute<LoginRoute>(path: '/login')
-class LoginRoute extends GoRouteData {
-  const LoginRoute();
+@TypedGoRoute<DicoveryRoute>(path: '/discovery')
+class DicoveryRoute extends GoRouteData {
+  const DicoveryRoute();
 
   @override
   Widget build(BuildContext context, GoRouterState state) {
-    return const LoginPage();
+    return const DiscoveryServersPage();
+  }
+}
+
+@TypedGoRoute<EnterAddressRoute>(path: '/manualAddres')
+class EnterAddressRoute extends GoRouteData {
+  const EnterAddressRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) {
+    return const EnterAddressPage();
   }
 }
 

--- a/lib/router/routes.dart
+++ b/lib/router/routes.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'package:hommie/features/auth/presentation/screens/discovery_servers_page.dart';
+import 'package:hommie/features/auth/presentation/screens/server_discovery_page.dart';
 import 'package:hommie/features/home/presentation/screens/home_page.dart';
 import 'package:hommie/features/auth/presentation/screens/enter_address_page.dart';
 import 'package:hommie/features/home/presentation/screens/root_page.dart';
@@ -115,7 +115,7 @@ class DicoveryRoute extends GoRouteData {
 
   @override
   Widget build(BuildContext context, GoRouterState state) {
-    return const DiscoveryServersPage();
+    return const ServerDiscoveryPage();
   }
 }
 

--- a/lib/router/routes.g.dart
+++ b/lib/router/routes.g.dart
@@ -11,7 +11,8 @@ List<RouteBase> get $appRoutes => [
       $aboutRouteData,
       $sensorsRouteData,
       $hubRouteData,
-      $loginRoute,
+      $dicoveryRoute,
+      $enterAddressRoute,
       $startupRoute,
     ];
 
@@ -145,16 +146,39 @@ extension $HubRouteDataExtension on HubRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
-RouteBase get $loginRoute => GoRouteData.$route(
-      path: '/login',
-      factory: $LoginRouteExtension._fromState,
+RouteBase get $dicoveryRoute => GoRouteData.$route(
+      path: '/discovery',
+      factory: $DicoveryRouteExtension._fromState,
     );
 
-extension $LoginRouteExtension on LoginRoute {
-  static LoginRoute _fromState(GoRouterState state) => const LoginRoute();
+extension $DicoveryRouteExtension on DicoveryRoute {
+  static DicoveryRoute _fromState(GoRouterState state) => const DicoveryRoute();
 
   String get location => GoRouteData.$location(
-        '/login',
+        '/discovery',
+      );
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+RouteBase get $enterAddressRoute => GoRouteData.$route(
+      path: '/manualAddres',
+      factory: $EnterAddressRouteExtension._fromState,
+    );
+
+extension $EnterAddressRouteExtension on EnterAddressRoute {
+  static EnterAddressRoute _fromState(GoRouterState state) =>
+      const EnterAddressRoute();
+
+  String get location => GoRouteData.$location(
+        '/manualAddres',
       );
 
   void go(BuildContext context) => context.go(location);

--- a/lib/services/networking/provider.dart
+++ b/lib/services/networking/provider.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:hommie/features/auth/auth_provider.dart';
+import 'package:hommie/features/auth/auth_repository_provider.dart';
 import 'package:hommie/services/networking/home_assitant_websocket/ha_socket.dart';
 import 'package:hommie/services/networking/home_assitant_websocket/ha_connection.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -674,6 +674,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.4.4"
+  multicast_dns:
+    dependency: "direct main"
+    description:
+      name: multicast_dns
+      sha256: "982c4cc4cda5f98dd477bddfd623e8e4bd1014e7dbf9e7b05052e14a5b550b99"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.2+7"
   network_info_plus:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   battery_plus: ^6.2.0
   connectivity_plus: ^6.1.0
   network_info_plus: ^6.1.1
+  multicast_dns: ^0.3.2+7
 
 dev_dependencies:
   build_runner:


### PR DESCRIPTION
**Summary**

This PR implements the “Discovery Home Assistant Servers” feature, simplifying the setup process for users. Instead of manually entering the server address, users are now presented with a Servers Discovery page during authentication.

**Key Changes**

1. Servers Discovery Page
- Displays a list of available Home Assistant (HA) servers detected on the user’s network.
- Users can select a server from the list instead of entering the address manually.
- Client automatically browse for new servers each 10 seconds

2. Integration of `MDnsClient` Library
- Utilizes the MDnsClient library to search for `_home-assistant._tcp` services in the local network.
- Extracts information from TXT records and maps the data into a user-friendly list of available servers.

**Notes**

This feature streamlines the onboarding process and reduces manual input for users during setup. Let me know if further refinements are needed!

![photo_2024-11-27 10 21 05](https://github.com/user-attachments/assets/feb12ce3-2093-4222-874e-d9d9eb0be100)