### PR TITLE
Allign with official WS communication library.

### DIFF
--- a/packages/home_assistant_websocket/lib/src/types/hass_event.freezed.dart
+++ b/packages/home_assistant_websocket/lib/src/types/hass_event.freezed.dart
@@ -14,47 +14,47 @@ T _$identity<T>(T value) => value;
 
 /// @nodoc
 mixin _$EntityStateRemove {
-  List<String> get a;
 
-  /// Create a copy of EntityStateRemove
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $EntityStateRemoveCopyWith<EntityStateRemove> get copyWith =>
-      _$EntityStateRemoveCopyWithImpl<EntityStateRemove>(
-          this as EntityStateRemove, _$identity);
+ List<String> get a;
+/// Create a copy of EntityStateRemove
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$EntityStateRemoveCopyWith<EntityStateRemove> get copyWith => _$EntityStateRemoveCopyWithImpl<EntityStateRemove>(this as EntityStateRemove, _$identity);
 
   /// Serializes this EntityStateRemove to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is EntityStateRemove &&
-            const DeepCollectionEquality().equals(other.a, a));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode =>
-      Object.hash(runtimeType, const DeepCollectionEquality().hash(a));
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EntityStateRemove&&const DeepCollectionEquality().equals(other.a, a));
+}
 
-  @override
-  String toString() {
-    return 'EntityStateRemove(a: $a)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(a));
+
+@override
+String toString() {
+  return 'EntityStateRemove(a: $a)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $EntityStateRemoveCopyWith<$Res> {
-  factory $EntityStateRemoveCopyWith(
-          EntityStateRemove value, $Res Function(EntityStateRemove) _then) =
-      _$EntityStateRemoveCopyWithImpl;
-  @useResult
-  $Res call({List<String> a});
-}
+abstract mixin class $EntityStateRemoveCopyWith<$Res>  {
+  factory $EntityStateRemoveCopyWith(EntityStateRemove value, $Res Function(EntityStateRemove) _then) = _$EntityStateRemoveCopyWithImpl;
+@useResult
+$Res call({
+ List<String> a
+});
 
+
+
+
+}
 /// @nodoc
 class _$EntityStateRemoveCopyWithImpl<$Res>
     implements $EntityStateRemoveCopyWith<$Res> {
@@ -63,235 +63,197 @@ class _$EntityStateRemoveCopyWithImpl<$Res>
   final EntityStateRemove _self;
   final $Res Function(EntityStateRemove) _then;
 
-  /// Create a copy of EntityStateRemove
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? a = null,
-  }) {
-    return _then(_self.copyWith(
-      a: null == a
-          ? _self.a
-          : a // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-    ));
-  }
+/// Create a copy of EntityStateRemove
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? a = null,}) {
+  return _then(_self.copyWith(
+a: null == a ? _self.a : a // ignore: cast_nullable_to_non_nullable
+as List<String>,
+  ));
 }
+
+}
+
 
 /// Adds pattern-matching-related methods to [EntityStateRemove].
 extension EntityStateRemovePatterns on EntityStateRemove {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_EntityStateRemove value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _EntityStateRemove() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _EntityStateRemove value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _EntityStateRemove() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_EntityStateRemove value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _EntityStateRemove():
-        return $default(_that);
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _EntityStateRemove value)  $default,){
+final _that = this;
+switch (_that) {
+case _EntityStateRemove():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _EntityStateRemove value)?  $default,){
+final _that = this;
+switch (_that) {
+case _EntityStateRemove() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_EntityStateRemove value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _EntityStateRemove() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( List<String> a)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _EntityStateRemove() when $default != null:
+return $default(_that.a);case _:
+  return orElse();
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(List<String> a)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _EntityStateRemove() when $default != null:
-        return $default(_that.a);
-      case _:
-        return orElse();
-    }
-  }
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( List<String> a)  $default,) {final _that = this;
+switch (_that) {
+case _EntityStateRemove():
+return $default(_that.a);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(List<String> a) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _EntityStateRemove():
-        return $default(_that.a);
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( List<String> a)?  $default,) {final _that = this;
+switch (_that) {
+case _EntityStateRemove() when $default != null:
+return $default(_that.a);case _:
+  return null;
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(List<String> a)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _EntityStateRemove() when $default != null:
-        return $default(_that.a);
-      case _:
-        return null;
-    }
-  }
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _EntityStateRemove implements EntityStateRemove {
-  _EntityStateRemove(final List<String> a) : _a = a;
-  factory _EntityStateRemove.fromJson(Map<String, dynamic> json) =>
-      _$EntityStateRemoveFromJson(json);
+   _EntityStateRemove(final  List<String> a): _a = a;
+  factory _EntityStateRemove.fromJson(Map<String, dynamic> json) => _$EntityStateRemoveFromJson(json);
 
-  final List<String> _a;
-  @override
-  List<String> get a {
-    if (_a is EqualUnmodifiableListView) return _a;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_a);
-  }
+ final  List<String> _a;
+@override List<String> get a {
+  if (_a is EqualUnmodifiableListView) return _a;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_a);
+}
 
-  /// Create a copy of EntityStateRemove
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$EntityStateRemoveCopyWith<_EntityStateRemove> get copyWith =>
-      __$EntityStateRemoveCopyWithImpl<_EntityStateRemove>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$EntityStateRemoveToJson(
-      this,
-    );
-  }
+/// Create a copy of EntityStateRemove
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$EntityStateRemoveCopyWith<_EntityStateRemove> get copyWith => __$EntityStateRemoveCopyWithImpl<_EntityStateRemove>(this, _$identity);
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _EntityStateRemove &&
-            const DeepCollectionEquality().equals(other._a, _a));
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$EntityStateRemoveToJson(this, );
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode =>
-      Object.hash(runtimeType, const DeepCollectionEquality().hash(_a));
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EntityStateRemove&&const DeepCollectionEquality().equals(other._a, _a));
+}
 
-  @override
-  String toString() {
-    return 'EntityStateRemove(a: $a)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_a));
+
+@override
+String toString() {
+  return 'EntityStateRemove(a: $a)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class _$EntityStateRemoveCopyWith<$Res>
-    implements $EntityStateRemoveCopyWith<$Res> {
-  factory _$EntityStateRemoveCopyWith(
-          _EntityStateRemove value, $Res Function(_EntityStateRemove) _then) =
-      __$EntityStateRemoveCopyWithImpl;
-  @override
-  @useResult
-  $Res call({List<String> a});
-}
+abstract mixin class _$EntityStateRemoveCopyWith<$Res> implements $EntityStateRemoveCopyWith<$Res> {
+  factory _$EntityStateRemoveCopyWith(_EntityStateRemove value, $Res Function(_EntityStateRemove) _then) = __$EntityStateRemoveCopyWithImpl;
+@override @useResult
+$Res call({
+ List<String> a
+});
 
+
+
+
+}
 /// @nodoc
 class __$EntityStateRemoveCopyWithImpl<$Res>
     implements _$EntityStateRemoveCopyWith<$Res> {
@@ -300,925 +262,671 @@ class __$EntityStateRemoveCopyWithImpl<$Res>
   final _EntityStateRemove _self;
   final $Res Function(_EntityStateRemove) _then;
 
-  /// Create a copy of EntityStateRemove
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? a = null,
-  }) {
-    return _then(_EntityStateRemove(
-      null == a
-          ? _self._a
-          : a // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-    ));
-  }
+/// Create a copy of EntityStateRemove
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? a = null,}) {
+  return _then(_EntityStateRemove(
+null == a ? _self._a : a // ignore: cast_nullable_to_non_nullable
+as List<String>,
+  ));
 }
+
+
+}
+
 
 /// @nodoc
 mixin _$EntityState {
-  @JsonKey(name: 's')
-  String? get state;
-  @JsonKey(name: 'a')
-  Map<String, dynamic>? get attributes;
-  @JsonKey(name: 'c')
-  Context? get context;
-  @JsonKey(name: 'ls')
-  double? get last_changed;
-  @JsonKey(name: 'lu')
-  double? get last_updated;
 
-  /// Create a copy of EntityState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $EntityStateCopyWith<EntityState> get copyWith =>
-      _$EntityStateCopyWithImpl<EntityState>(this as EntityState, _$identity);
+@JsonKey(name: 's') String? get state;@JsonKey(name: 'a') Map<String, dynamic>? get attributes;@JsonKey(name: 'c') Context? get context;@JsonKey(name: 'ls') double? get last_changed;@JsonKey(name: 'lu') double? get last_updated;
+/// Create a copy of EntityState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$EntityStateCopyWith<EntityState> get copyWith => _$EntityStateCopyWithImpl<EntityState>(this as EntityState, _$identity);
 
   /// Serializes this EntityState to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is EntityState &&
-            (identical(other.state, state) || other.state == state) &&
-            const DeepCollectionEquality()
-                .equals(other.attributes, attributes) &&
-            (identical(other.context, context) || other.context == context) &&
-            (identical(other.last_changed, last_changed) ||
-                other.last_changed == last_changed) &&
-            (identical(other.last_updated, last_updated) ||
-                other.last_updated == last_updated));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      state,
-      const DeepCollectionEquality().hash(attributes),
-      context,
-      last_changed,
-      last_updated);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EntityState&&(identical(other.state, state) || other.state == state)&&const DeepCollectionEquality().equals(other.attributes, attributes)&&(identical(other.context, context) || other.context == context)&&(identical(other.last_changed, last_changed) || other.last_changed == last_changed)&&(identical(other.last_updated, last_updated) || other.last_updated == last_updated));
+}
 
-  @override
-  String toString() {
-    return 'EntityState(state: $state, attributes: $attributes, context: $context, last_changed: $last_changed, last_updated: $last_updated)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,state,const DeepCollectionEquality().hash(attributes),context,last_changed,last_updated);
+
+@override
+String toString() {
+  return 'EntityState(state: $state, attributes: $attributes, context: $context, last_changed: $last_changed, last_updated: $last_updated)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $EntityStateCopyWith<$Res> {
-  factory $EntityStateCopyWith(
-          EntityState value, $Res Function(EntityState) _then) =
-      _$EntityStateCopyWithImpl;
-  @useResult
-  $Res call(
-      {@JsonKey(name: 's') String? state,
-      @JsonKey(name: 'a') Map<String, dynamic>? attributes,
-      @JsonKey(name: 'c') Context? context,
-      @JsonKey(name: 'ls') double? last_changed,
-      @JsonKey(name: 'lu') double? last_updated});
+abstract mixin class $EntityStateCopyWith<$Res>  {
+  factory $EntityStateCopyWith(EntityState value, $Res Function(EntityState) _then) = _$EntityStateCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 's') String? state,@JsonKey(name: 'a') Map<String, dynamic>? attributes,@JsonKey(name: 'c') Context? context,@JsonKey(name: 'ls') double? last_changed,@JsonKey(name: 'lu') double? last_updated
+});
 
-  $ContextCopyWith<$Res>? get context;
+
+$ContextCopyWith<$Res>? get context;
+
 }
-
 /// @nodoc
-class _$EntityStateCopyWithImpl<$Res> implements $EntityStateCopyWith<$Res> {
+class _$EntityStateCopyWithImpl<$Res>
+    implements $EntityStateCopyWith<$Res> {
   _$EntityStateCopyWithImpl(this._self, this._then);
 
   final EntityState _self;
   final $Res Function(EntityState) _then;
 
-  /// Create a copy of EntityState
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? state = freezed,
-    Object? attributes = freezed,
-    Object? context = freezed,
-    Object? last_changed = freezed,
-    Object? last_updated = freezed,
-  }) {
-    return _then(_self.copyWith(
-      state: freezed == state
-          ? _self.state
-          : state // ignore: cast_nullable_to_non_nullable
-              as String?,
-      attributes: freezed == attributes
-          ? _self.attributes
-          : attributes // ignore: cast_nullable_to_non_nullable
-              as Map<String, dynamic>?,
-      context: freezed == context
-          ? _self.context
-          : context // ignore: cast_nullable_to_non_nullable
-              as Context?,
-      last_changed: freezed == last_changed
-          ? _self.last_changed
-          : last_changed // ignore: cast_nullable_to_non_nullable
-              as double?,
-      last_updated: freezed == last_updated
-          ? _self.last_updated
-          : last_updated // ignore: cast_nullable_to_non_nullable
-              as double?,
-    ));
-  }
-
-  /// Create a copy of EntityState
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $ContextCopyWith<$Res>? get context {
-    if (_self.context == null) {
-      return null;
-    }
-
-    return $ContextCopyWith<$Res>(_self.context!, (value) {
-      return _then(_self.copyWith(context: value));
-    });
-  }
+/// Create a copy of EntityState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? state = freezed,Object? attributes = freezed,Object? context = freezed,Object? last_changed = freezed,Object? last_updated = freezed,}) {
+  return _then(_self.copyWith(
+state: freezed == state ? _self.state : state // ignore: cast_nullable_to_non_nullable
+as String?,attributes: freezed == attributes ? _self.attributes : attributes // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,context: freezed == context ? _self.context : context // ignore: cast_nullable_to_non_nullable
+as Context?,last_changed: freezed == last_changed ? _self.last_changed : last_changed // ignore: cast_nullable_to_non_nullable
+as double?,last_updated: freezed == last_updated ? _self.last_updated : last_updated // ignore: cast_nullable_to_non_nullable
+as double?,
+  ));
 }
+/// Create a copy of EntityState
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$ContextCopyWith<$Res>? get context {
+    if (_self.context == null) {
+    return null;
+  }
+
+  return $ContextCopyWith<$Res>(_self.context!, (value) {
+    return _then(_self.copyWith(context: value));
+  });
+}
+}
+
 
 /// Adds pattern-matching-related methods to [EntityState].
 extension EntityStatePatterns on EntityState {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_EntityState value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _EntityState() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _EntityState value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _EntityState() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_EntityState value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _EntityState():
-        return $default(_that);
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _EntityState value)  $default,){
+final _that = this;
+switch (_that) {
+case _EntityState():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _EntityState value)?  $default,){
+final _that = this;
+switch (_that) {
+case _EntityState() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_EntityState value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _EntityState() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 's')  String? state, @JsonKey(name: 'a')  Map<String, dynamic>? attributes, @JsonKey(name: 'c')  Context? context, @JsonKey(name: 'ls')  double? last_changed, @JsonKey(name: 'lu')  double? last_updated)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _EntityState() when $default != null:
+return $default(_that.state,_that.attributes,_that.context,_that.last_changed,_that.last_updated);case _:
+  return orElse();
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(
-            @JsonKey(name: 's') String? state,
-            @JsonKey(name: 'a') Map<String, dynamic>? attributes,
-            @JsonKey(name: 'c') Context? context,
-            @JsonKey(name: 'ls') double? last_changed,
-            @JsonKey(name: 'lu') double? last_updated)?
-        $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _EntityState() when $default != null:
-        return $default(_that.state, _that.attributes, _that.context,
-            _that.last_changed, _that.last_updated);
-      case _:
-        return orElse();
-    }
-  }
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 's')  String? state, @JsonKey(name: 'a')  Map<String, dynamic>? attributes, @JsonKey(name: 'c')  Context? context, @JsonKey(name: 'ls')  double? last_changed, @JsonKey(name: 'lu')  double? last_updated)  $default,) {final _that = this;
+switch (_that) {
+case _EntityState():
+return $default(_that.state,_that.attributes,_that.context,_that.last_changed,_that.last_updated);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(
-            @JsonKey(name: 's') String? state,
-            @JsonKey(name: 'a') Map<String, dynamic>? attributes,
-            @JsonKey(name: 'c') Context? context,
-            @JsonKey(name: 'ls') double? last_changed,
-            @JsonKey(name: 'lu') double? last_updated)
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _EntityState():
-        return $default(_that.state, _that.attributes, _that.context,
-            _that.last_changed, _that.last_updated);
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 's')  String? state, @JsonKey(name: 'a')  Map<String, dynamic>? attributes, @JsonKey(name: 'c')  Context? context, @JsonKey(name: 'ls')  double? last_changed, @JsonKey(name: 'lu')  double? last_updated)?  $default,) {final _that = this;
+switch (_that) {
+case _EntityState() when $default != null:
+return $default(_that.state,_that.attributes,_that.context,_that.last_changed,_that.last_updated);case _:
+  return null;
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(
-            @JsonKey(name: 's') String? state,
-            @JsonKey(name: 'a') Map<String, dynamic>? attributes,
-            @JsonKey(name: 'c') Context? context,
-            @JsonKey(name: 'ls') double? last_changed,
-            @JsonKey(name: 'lu') double? last_updated)?
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _EntityState() when $default != null:
-        return $default(_that.state, _that.attributes, _that.context,
-            _that.last_changed, _that.last_updated);
-      case _:
-        return null;
-    }
-  }
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _EntityState implements EntityState {
-  _EntityState(
-      {@JsonKey(name: 's') this.state,
-      @JsonKey(name: 'a') final Map<String, dynamic>? attributes,
-      @JsonKey(name: 'c') this.context,
-      @JsonKey(name: 'ls') this.last_changed,
-      @JsonKey(name: 'lu') this.last_updated})
-      : _attributes = attributes;
-  factory _EntityState.fromJson(Map<String, dynamic> json) =>
-      _$EntityStateFromJson(json);
+   _EntityState({@JsonKey(name: 's') this.state, @JsonKey(name: 'a') final  Map<String, dynamic>? attributes, @JsonKey(name: 'c') this.context, @JsonKey(name: 'ls') this.last_changed, @JsonKey(name: 'lu') this.last_updated}): _attributes = attributes;
+  factory _EntityState.fromJson(Map<String, dynamic> json) => _$EntityStateFromJson(json);
 
-  @override
-  @JsonKey(name: 's')
-  final String? state;
-  final Map<String, dynamic>? _attributes;
-  @override
-  @JsonKey(name: 'a')
-  Map<String, dynamic>? get attributes {
-    final value = _attributes;
-    if (value == null) return null;
-    if (_attributes is EqualUnmodifiableMapView) return _attributes;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableMapView(value);
-  }
+@override@JsonKey(name: 's') final  String? state;
+ final  Map<String, dynamic>? _attributes;
+@override@JsonKey(name: 'a') Map<String, dynamic>? get attributes {
+  final value = _attributes;
+  if (value == null) return null;
+  if (_attributes is EqualUnmodifiableMapView) return _attributes;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(value);
+}
 
-  @override
-  @JsonKey(name: 'c')
-  final Context? context;
-  @override
-  @JsonKey(name: 'ls')
-  final double? last_changed;
-  @override
-  @JsonKey(name: 'lu')
-  final double? last_updated;
+@override@JsonKey(name: 'c') final  Context? context;
+@override@JsonKey(name: 'ls') final  double? last_changed;
+@override@JsonKey(name: 'lu') final  double? last_updated;
 
-  /// Create a copy of EntityState
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$EntityStateCopyWith<_EntityState> get copyWith =>
-      __$EntityStateCopyWithImpl<_EntityState>(this, _$identity);
+/// Create a copy of EntityState
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$EntityStateCopyWith<_EntityState> get copyWith => __$EntityStateCopyWithImpl<_EntityState>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$EntityStateToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$EntityStateToJson(this, );
+}
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _EntityState &&
-            (identical(other.state, state) || other.state == state) &&
-            const DeepCollectionEquality()
-                .equals(other._attributes, _attributes) &&
-            (identical(other.context, context) || other.context == context) &&
-            (identical(other.last_changed, last_changed) ||
-                other.last_changed == last_changed) &&
-            (identical(other.last_updated, last_updated) ||
-                other.last_updated == last_updated));
-  }
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EntityState&&(identical(other.state, state) || other.state == state)&&const DeepCollectionEquality().equals(other._attributes, _attributes)&&(identical(other.context, context) || other.context == context)&&(identical(other.last_changed, last_changed) || other.last_changed == last_changed)&&(identical(other.last_updated, last_updated) || other.last_updated == last_updated));
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      state,
-      const DeepCollectionEquality().hash(_attributes),
-      context,
-      last_changed,
-      last_updated);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,state,const DeepCollectionEquality().hash(_attributes),context,last_changed,last_updated);
 
-  @override
-  String toString() {
-    return 'EntityState(state: $state, attributes: $attributes, context: $context, last_changed: $last_changed, last_updated: $last_updated)';
-  }
+@override
+String toString() {
+  return 'EntityState(state: $state, attributes: $attributes, context: $context, last_changed: $last_changed, last_updated: $last_updated)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class _$EntityStateCopyWith<$Res>
-    implements $EntityStateCopyWith<$Res> {
-  factory _$EntityStateCopyWith(
-          _EntityState value, $Res Function(_EntityState) _then) =
-      __$EntityStateCopyWithImpl;
-  @override
-  @useResult
-  $Res call(
-      {@JsonKey(name: 's') String? state,
-      @JsonKey(name: 'a') Map<String, dynamic>? attributes,
-      @JsonKey(name: 'c') Context? context,
-      @JsonKey(name: 'ls') double? last_changed,
-      @JsonKey(name: 'lu') double? last_updated});
+abstract mixin class _$EntityStateCopyWith<$Res> implements $EntityStateCopyWith<$Res> {
+  factory _$EntityStateCopyWith(_EntityState value, $Res Function(_EntityState) _then) = __$EntityStateCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 's') String? state,@JsonKey(name: 'a') Map<String, dynamic>? attributes,@JsonKey(name: 'c') Context? context,@JsonKey(name: 'ls') double? last_changed,@JsonKey(name: 'lu') double? last_updated
+});
 
-  @override
-  $ContextCopyWith<$Res>? get context;
+
+@override $ContextCopyWith<$Res>? get context;
+
 }
-
 /// @nodoc
-class __$EntityStateCopyWithImpl<$Res> implements _$EntityStateCopyWith<$Res> {
+class __$EntityStateCopyWithImpl<$Res>
+    implements _$EntityStateCopyWith<$Res> {
   __$EntityStateCopyWithImpl(this._self, this._then);
 
   final _EntityState _self;
   final $Res Function(_EntityState) _then;
 
-  /// Create a copy of EntityState
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? state = freezed,
-    Object? attributes = freezed,
-    Object? context = freezed,
-    Object? last_changed = freezed,
-    Object? last_updated = freezed,
-  }) {
-    return _then(_EntityState(
-      state: freezed == state
-          ? _self.state
-          : state // ignore: cast_nullable_to_non_nullable
-              as String?,
-      attributes: freezed == attributes
-          ? _self._attributes
-          : attributes // ignore: cast_nullable_to_non_nullable
-              as Map<String, dynamic>?,
-      context: freezed == context
-          ? _self.context
-          : context // ignore: cast_nullable_to_non_nullable
-              as Context?,
-      last_changed: freezed == last_changed
-          ? _self.last_changed
-          : last_changed // ignore: cast_nullable_to_non_nullable
-              as double?,
-      last_updated: freezed == last_updated
-          ? _self.last_updated
-          : last_updated // ignore: cast_nullable_to_non_nullable
-              as double?,
-    ));
-  }
-
-  /// Create a copy of EntityState
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $ContextCopyWith<$Res>? get context {
-    if (_self.context == null) {
-      return null;
-    }
-
-    return $ContextCopyWith<$Res>(_self.context!, (value) {
-      return _then(_self.copyWith(context: value));
-    });
-  }
+/// Create a copy of EntityState
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? state = freezed,Object? attributes = freezed,Object? context = freezed,Object? last_changed = freezed,Object? last_updated = freezed,}) {
+  return _then(_EntityState(
+state: freezed == state ? _self.state : state // ignore: cast_nullable_to_non_nullable
+as String?,attributes: freezed == attributes ? _self._attributes : attributes // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,context: freezed == context ? _self.context : context // ignore: cast_nullable_to_non_nullable
+as Context?,last_changed: freezed == last_changed ? _self.last_changed : last_changed // ignore: cast_nullable_to_non_nullable
+as double?,last_updated: freezed == last_updated ? _self.last_updated : last_updated // ignore: cast_nullable_to_non_nullable
+as double?,
+  ));
 }
+
+/// Create a copy of EntityState
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$ContextCopyWith<$Res>? get context {
+    if (_self.context == null) {
+    return null;
+  }
+
+  return $ContextCopyWith<$Res>(_self.context!, (value) {
+    return _then(_self.copyWith(context: value));
+  });
+}
+}
+
 
 /// @nodoc
 mixin _$EntityDiff {
-  @JsonKey(name: '+')
-  EntityState? get add;
-  @JsonKey(name: '-')
-  EntityStateRemove? get remove;
 
-  /// Create a copy of EntityDiff
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $EntityDiffCopyWith<EntityDiff> get copyWith =>
-      _$EntityDiffCopyWithImpl<EntityDiff>(this as EntityDiff, _$identity);
+@JsonKey(name: '+') EntityState? get add;@JsonKey(name: '-') EntityStateRemove? get remove;
+/// Create a copy of EntityDiff
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$EntityDiffCopyWith<EntityDiff> get copyWith => _$EntityDiffCopyWithImpl<EntityDiff>(this as EntityDiff, _$identity);
 
   /// Serializes this EntityDiff to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is EntityDiff &&
-            (identical(other.add, add) || other.add == add) &&
-            (identical(other.remove, remove) || other.remove == remove));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(runtimeType, add, remove);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EntityDiff&&(identical(other.add, add) || other.add == add)&&(identical(other.remove, remove) || other.remove == remove));
+}
 
-  @override
-  String toString() {
-    return 'EntityDiff(add: $add, remove: $remove)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,add,remove);
+
+@override
+String toString() {
+  return 'EntityDiff(add: $add, remove: $remove)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $EntityDiffCopyWith<$Res> {
-  factory $EntityDiffCopyWith(
-          EntityDiff value, $Res Function(EntityDiff) _then) =
-      _$EntityDiffCopyWithImpl;
-  @useResult
-  $Res call(
-      {@JsonKey(name: '+') EntityState? add,
-      @JsonKey(name: '-') EntityStateRemove? remove});
+abstract mixin class $EntityDiffCopyWith<$Res>  {
+  factory $EntityDiffCopyWith(EntityDiff value, $Res Function(EntityDiff) _then) = _$EntityDiffCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: '+') EntityState? add,@JsonKey(name: '-') EntityStateRemove? remove
+});
 
-  $EntityStateCopyWith<$Res>? get add;
-  $EntityStateRemoveCopyWith<$Res>? get remove;
+
+$EntityStateCopyWith<$Res>? get add;$EntityStateRemoveCopyWith<$Res>? get remove;
+
 }
-
 /// @nodoc
-class _$EntityDiffCopyWithImpl<$Res> implements $EntityDiffCopyWith<$Res> {
+class _$EntityDiffCopyWithImpl<$Res>
+    implements $EntityDiffCopyWith<$Res> {
   _$EntityDiffCopyWithImpl(this._self, this._then);
 
   final EntityDiff _self;
   final $Res Function(EntityDiff) _then;
 
-  /// Create a copy of EntityDiff
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? add = freezed,
-    Object? remove = freezed,
-  }) {
-    return _then(_self.copyWith(
-      add: freezed == add
-          ? _self.add
-          : add // ignore: cast_nullable_to_non_nullable
-              as EntityState?,
-      remove: freezed == remove
-          ? _self.remove
-          : remove // ignore: cast_nullable_to_non_nullable
-              as EntityStateRemove?,
-    ));
-  }
-
-  /// Create a copy of EntityDiff
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $EntityStateCopyWith<$Res>? get add {
-    if (_self.add == null) {
-      return null;
-    }
-
-    return $EntityStateCopyWith<$Res>(_self.add!, (value) {
-      return _then(_self.copyWith(add: value));
-    });
-  }
-
-  /// Create a copy of EntityDiff
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $EntityStateRemoveCopyWith<$Res>? get remove {
-    if (_self.remove == null) {
-      return null;
-    }
-
-    return $EntityStateRemoveCopyWith<$Res>(_self.remove!, (value) {
-      return _then(_self.copyWith(remove: value));
-    });
-  }
+/// Create a copy of EntityDiff
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? add = freezed,Object? remove = freezed,}) {
+  return _then(_self.copyWith(
+add: freezed == add ? _self.add : add // ignore: cast_nullable_to_non_nullable
+as EntityState?,remove: freezed == remove ? _self.remove : remove // ignore: cast_nullable_to_non_nullable
+as EntityStateRemove?,
+  ));
 }
+/// Create a copy of EntityDiff
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$EntityStateCopyWith<$Res>? get add {
+    if (_self.add == null) {
+    return null;
+  }
+
+  return $EntityStateCopyWith<$Res>(_self.add!, (value) {
+    return _then(_self.copyWith(add: value));
+  });
+}/// Create a copy of EntityDiff
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$EntityStateRemoveCopyWith<$Res>? get remove {
+    if (_self.remove == null) {
+    return null;
+  }
+
+  return $EntityStateRemoveCopyWith<$Res>(_self.remove!, (value) {
+    return _then(_self.copyWith(remove: value));
+  });
+}
+}
+
 
 /// Adds pattern-matching-related methods to [EntityDiff].
 extension EntityDiffPatterns on EntityDiff {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_EntityDiff value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _EntityDiff() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _EntityDiff value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _EntityDiff() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_EntityDiff value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _EntityDiff():
-        return $default(_that);
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _EntityDiff value)  $default,){
+final _that = this;
+switch (_that) {
+case _EntityDiff():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _EntityDiff value)?  $default,){
+final _that = this;
+switch (_that) {
+case _EntityDiff() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_EntityDiff value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _EntityDiff() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: '+')  EntityState? add, @JsonKey(name: '-')  EntityStateRemove? remove)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _EntityDiff() when $default != null:
+return $default(_that.add,_that.remove);case _:
+  return orElse();
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(@JsonKey(name: '+') EntityState? add,
-            @JsonKey(name: '-') EntityStateRemove? remove)?
-        $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _EntityDiff() when $default != null:
-        return $default(_that.add, _that.remove);
-      case _:
-        return orElse();
-    }
-  }
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: '+')  EntityState? add, @JsonKey(name: '-')  EntityStateRemove? remove)  $default,) {final _that = this;
+switch (_that) {
+case _EntityDiff():
+return $default(_that.add,_that.remove);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(@JsonKey(name: '+') EntityState? add,
-            @JsonKey(name: '-') EntityStateRemove? remove)
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _EntityDiff():
-        return $default(_that.add, _that.remove);
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: '+')  EntityState? add, @JsonKey(name: '-')  EntityStateRemove? remove)?  $default,) {final _that = this;
+switch (_that) {
+case _EntityDiff() when $default != null:
+return $default(_that.add,_that.remove);case _:
+  return null;
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(@JsonKey(name: '+') EntityState? add,
-            @JsonKey(name: '-') EntityStateRemove? remove)?
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _EntityDiff() when $default != null:
-        return $default(_that.add, _that.remove);
-      case _:
-        return null;
-    }
-  }
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _EntityDiff implements EntityDiff {
-  _EntityDiff({@JsonKey(name: '+') this.add, @JsonKey(name: '-') this.remove});
-  factory _EntityDiff.fromJson(Map<String, dynamic> json) =>
-      _$EntityDiffFromJson(json);
+   _EntityDiff({@JsonKey(name: '+') this.add, @JsonKey(name: '-') this.remove});
+  factory _EntityDiff.fromJson(Map<String, dynamic> json) => _$EntityDiffFromJson(json);
 
-  @override
-  @JsonKey(name: '+')
-  final EntityState? add;
-  @override
-  @JsonKey(name: '-')
-  final EntityStateRemove? remove;
+@override@JsonKey(name: '+') final  EntityState? add;
+@override@JsonKey(name: '-') final  EntityStateRemove? remove;
 
-  /// Create a copy of EntityDiff
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$EntityDiffCopyWith<_EntityDiff> get copyWith =>
-      __$EntityDiffCopyWithImpl<_EntityDiff>(this, _$identity);
+/// Create a copy of EntityDiff
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$EntityDiffCopyWith<_EntityDiff> get copyWith => __$EntityDiffCopyWithImpl<_EntityDiff>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$EntityDiffToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$EntityDiffToJson(this, );
+}
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _EntityDiff &&
-            (identical(other.add, add) || other.add == add) &&
-            (identical(other.remove, remove) || other.remove == remove));
-  }
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EntityDiff&&(identical(other.add, add) || other.add == add)&&(identical(other.remove, remove) || other.remove == remove));
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(runtimeType, add, remove);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,add,remove);
 
-  @override
-  String toString() {
-    return 'EntityDiff(add: $add, remove: $remove)';
-  }
+@override
+String toString() {
+  return 'EntityDiff(add: $add, remove: $remove)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class _$EntityDiffCopyWith<$Res>
-    implements $EntityDiffCopyWith<$Res> {
-  factory _$EntityDiffCopyWith(
-          _EntityDiff value, $Res Function(_EntityDiff) _then) =
-      __$EntityDiffCopyWithImpl;
-  @override
-  @useResult
-  $Res call(
-      {@JsonKey(name: '+') EntityState? add,
-      @JsonKey(name: '-') EntityStateRemove? remove});
+abstract mixin class _$EntityDiffCopyWith<$Res> implements $EntityDiffCopyWith<$Res> {
+  factory _$EntityDiffCopyWith(_EntityDiff value, $Res Function(_EntityDiff) _then) = __$EntityDiffCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: '+') EntityState? add,@JsonKey(name: '-') EntityStateRemove? remove
+});
 
-  @override
-  $EntityStateCopyWith<$Res>? get add;
-  @override
-  $EntityStateRemoveCopyWith<$Res>? get remove;
+
+@override $EntityStateCopyWith<$Res>? get add;@override $EntityStateRemoveCopyWith<$Res>? get remove;
+
 }
-
 /// @nodoc
-class __$EntityDiffCopyWithImpl<$Res> implements _$EntityDiffCopyWith<$Res> {
+class __$EntityDiffCopyWithImpl<$Res>
+    implements _$EntityDiffCopyWith<$Res> {
   __$EntityDiffCopyWithImpl(this._self, this._then);
 
   final _EntityDiff _self;
   final $Res Function(_EntityDiff) _then;
 
-  /// Create a copy of EntityDiff
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? add = freezed,
-    Object? remove = freezed,
-  }) {
-    return _then(_EntityDiff(
-      add: freezed == add
-          ? _self.add
-          : add // ignore: cast_nullable_to_non_nullable
-              as EntityState?,
-      remove: freezed == remove
-          ? _self.remove
-          : remove // ignore: cast_nullable_to_non_nullable
-              as EntityStateRemove?,
-    ));
-  }
-
-  /// Create a copy of EntityDiff
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $EntityStateCopyWith<$Res>? get add {
-    if (_self.add == null) {
-      return null;
-    }
-
-    return $EntityStateCopyWith<$Res>(_self.add!, (value) {
-      return _then(_self.copyWith(add: value));
-    });
-  }
-
-  /// Create a copy of EntityDiff
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $EntityStateRemoveCopyWith<$Res>? get remove {
-    if (_self.remove == null) {
-      return null;
-    }
-
-    return $EntityStateRemoveCopyWith<$Res>(_self.remove!, (value) {
-      return _then(_self.copyWith(remove: value));
-    });
-  }
+/// Create a copy of EntityDiff
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? add = freezed,Object? remove = freezed,}) {
+  return _then(_EntityDiff(
+add: freezed == add ? _self.add : add // ignore: cast_nullable_to_non_nullable
+as EntityState?,remove: freezed == remove ? _self.remove : remove // ignore: cast_nullable_to_non_nullable
+as EntityStateRemove?,
+  ));
 }
+
+/// Create a copy of EntityDiff
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$EntityStateCopyWith<$Res>? get add {
+    if (_self.add == null) {
+    return null;
+  }
+
+  return $EntityStateCopyWith<$Res>(_self.add!, (value) {
+    return _then(_self.copyWith(add: value));
+  });
+}/// Create a copy of EntityDiff
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$EntityStateRemoveCopyWith<$Res>? get remove {
+    if (_self.remove == null) {
+    return null;
+  }
+
+  return $EntityStateRemoveCopyWith<$Res>(_self.remove!, (value) {
+    return _then(_self.copyWith(remove: value));
+  });
+}
+}
+
 
 /// @nodoc
 mixin _$StatesUpdates {
-  @JsonKey(name: 'a')
-  Map<String, EntityState>? get add;
-  @JsonKey(name: 'r')
-  List<String>? get remove;
-  @JsonKey(name: 'c')
-  Map<String, EntityDiff>? get change;
 
-  /// Create a copy of StatesUpdates
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $StatesUpdatesCopyWith<StatesUpdates> get copyWith =>
-      _$StatesUpdatesCopyWithImpl<StatesUpdates>(
-          this as StatesUpdates, _$identity);
+@JsonKey(name: 'a') Map<String, EntityState>? get add;@JsonKey(name: 'r') List<String>? get remove;@JsonKey(name: 'c') Map<String, EntityDiff>? get change;
+/// Create a copy of StatesUpdates
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$StatesUpdatesCopyWith<StatesUpdates> get copyWith => _$StatesUpdatesCopyWithImpl<StatesUpdates>(this as StatesUpdates, _$identity);
 
   /// Serializes this StatesUpdates to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is StatesUpdates &&
-            const DeepCollectionEquality().equals(other.add, add) &&
-            const DeepCollectionEquality().equals(other.remove, remove) &&
-            const DeepCollectionEquality().equals(other.change, change));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(add),
-      const DeepCollectionEquality().hash(remove),
-      const DeepCollectionEquality().hash(change));
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is StatesUpdates&&const DeepCollectionEquality().equals(other.add, add)&&const DeepCollectionEquality().equals(other.remove, remove)&&const DeepCollectionEquality().equals(other.change, change));
+}
 
-  @override
-  String toString() {
-    return 'StatesUpdates(add: $add, remove: $remove, change: $change)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(add),const DeepCollectionEquality().hash(remove),const DeepCollectionEquality().hash(change));
+
+@override
+String toString() {
+  return 'StatesUpdates(add: $add, remove: $remove, change: $change)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $StatesUpdatesCopyWith<$Res> {
-  factory $StatesUpdatesCopyWith(
-          StatesUpdates value, $Res Function(StatesUpdates) _then) =
-      _$StatesUpdatesCopyWithImpl;
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'a') Map<String, EntityState>? add,
-      @JsonKey(name: 'r') List<String>? remove,
-      @JsonKey(name: 'c') Map<String, EntityDiff>? change});
-}
+abstract mixin class $StatesUpdatesCopyWith<$Res>  {
+  factory $StatesUpdatesCopyWith(StatesUpdates value, $Res Function(StatesUpdates) _then) = _$StatesUpdatesCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'a') Map<String, EntityState>? add,@JsonKey(name: 'r') List<String>? remove,@JsonKey(name: 'c') Map<String, EntityDiff>? change
+});
 
+
+
+
+}
 /// @nodoc
 class _$StatesUpdatesCopyWithImpl<$Res>
     implements $StatesUpdatesCopyWith<$Res> {
@@ -1227,296 +935,219 @@ class _$StatesUpdatesCopyWithImpl<$Res>
   final StatesUpdates _self;
   final $Res Function(StatesUpdates) _then;
 
-  /// Create a copy of StatesUpdates
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? add = freezed,
-    Object? remove = freezed,
-    Object? change = freezed,
-  }) {
-    return _then(_self.copyWith(
-      add: freezed == add
-          ? _self.add
-          : add // ignore: cast_nullable_to_non_nullable
-              as Map<String, EntityState>?,
-      remove: freezed == remove
-          ? _self.remove
-          : remove // ignore: cast_nullable_to_non_nullable
-              as List<String>?,
-      change: freezed == change
-          ? _self.change
-          : change // ignore: cast_nullable_to_non_nullable
-              as Map<String, EntityDiff>?,
-    ));
-  }
+/// Create a copy of StatesUpdates
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? add = freezed,Object? remove = freezed,Object? change = freezed,}) {
+  return _then(_self.copyWith(
+add: freezed == add ? _self.add : add // ignore: cast_nullable_to_non_nullable
+as Map<String, EntityState>?,remove: freezed == remove ? _self.remove : remove // ignore: cast_nullable_to_non_nullable
+as List<String>?,change: freezed == change ? _self.change : change // ignore: cast_nullable_to_non_nullable
+as Map<String, EntityDiff>?,
+  ));
 }
+
+}
+
 
 /// Adds pattern-matching-related methods to [StatesUpdates].
 extension StatesUpdatesPatterns on StatesUpdates {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_StatesUpdates value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _StatesUpdates() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _StatesUpdates value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _StatesUpdates() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_StatesUpdates value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _StatesUpdates():
-        return $default(_that);
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _StatesUpdates value)  $default,){
+final _that = this;
+switch (_that) {
+case _StatesUpdates():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _StatesUpdates value)?  $default,){
+final _that = this;
+switch (_that) {
+case _StatesUpdates() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_StatesUpdates value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _StatesUpdates() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'a')  Map<String, EntityState>? add, @JsonKey(name: 'r')  List<String>? remove, @JsonKey(name: 'c')  Map<String, EntityDiff>? change)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _StatesUpdates() when $default != null:
+return $default(_that.add,_that.remove,_that.change);case _:
+  return orElse();
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(
-            @JsonKey(name: 'a') Map<String, EntityState>? add,
-            @JsonKey(name: 'r') List<String>? remove,
-            @JsonKey(name: 'c') Map<String, EntityDiff>? change)?
-        $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _StatesUpdates() when $default != null:
-        return $default(_that.add, _that.remove, _that.change);
-      case _:
-        return orElse();
-    }
-  }
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'a')  Map<String, EntityState>? add, @JsonKey(name: 'r')  List<String>? remove, @JsonKey(name: 'c')  Map<String, EntityDiff>? change)  $default,) {final _that = this;
+switch (_that) {
+case _StatesUpdates():
+return $default(_that.add,_that.remove,_that.change);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(
-            @JsonKey(name: 'a') Map<String, EntityState>? add,
-            @JsonKey(name: 'r') List<String>? remove,
-            @JsonKey(name: 'c') Map<String, EntityDiff>? change)
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _StatesUpdates():
-        return $default(_that.add, _that.remove, _that.change);
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'a')  Map<String, EntityState>? add, @JsonKey(name: 'r')  List<String>? remove, @JsonKey(name: 'c')  Map<String, EntityDiff>? change)?  $default,) {final _that = this;
+switch (_that) {
+case _StatesUpdates() when $default != null:
+return $default(_that.add,_that.remove,_that.change);case _:
+  return null;
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(
-            @JsonKey(name: 'a') Map<String, EntityState>? add,
-            @JsonKey(name: 'r') List<String>? remove,
-            @JsonKey(name: 'c') Map<String, EntityDiff>? change)?
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _StatesUpdates() when $default != null:
-        return $default(_that.add, _that.remove, _that.change);
-      case _:
-        return null;
-    }
-  }
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _StatesUpdates implements StatesUpdates {
-  const _StatesUpdates(
-      {@JsonKey(name: 'a') final Map<String, EntityState>? add,
-      @JsonKey(name: 'r') final List<String>? remove,
-      @JsonKey(name: 'c') final Map<String, EntityDiff>? change})
-      : _add = add,
-        _remove = remove,
-        _change = change;
-  factory _StatesUpdates.fromJson(Map<String, dynamic> json) =>
-      _$StatesUpdatesFromJson(json);
+  const _StatesUpdates({@JsonKey(name: 'a') final  Map<String, EntityState>? add, @JsonKey(name: 'r') final  List<String>? remove, @JsonKey(name: 'c') final  Map<String, EntityDiff>? change}): _add = add,_remove = remove,_change = change;
+  factory _StatesUpdates.fromJson(Map<String, dynamic> json) => _$StatesUpdatesFromJson(json);
 
-  final Map<String, EntityState>? _add;
-  @override
-  @JsonKey(name: 'a')
-  Map<String, EntityState>? get add {
-    final value = _add;
-    if (value == null) return null;
-    if (_add is EqualUnmodifiableMapView) return _add;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableMapView(value);
-  }
+ final  Map<String, EntityState>? _add;
+@override@JsonKey(name: 'a') Map<String, EntityState>? get add {
+  final value = _add;
+  if (value == null) return null;
+  if (_add is EqualUnmodifiableMapView) return _add;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(value);
+}
 
-  final List<String>? _remove;
-  @override
-  @JsonKey(name: 'r')
-  List<String>? get remove {
-    final value = _remove;
-    if (value == null) return null;
-    if (_remove is EqualUnmodifiableListView) return _remove;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(value);
-  }
+ final  List<String>? _remove;
+@override@JsonKey(name: 'r') List<String>? get remove {
+  final value = _remove;
+  if (value == null) return null;
+  if (_remove is EqualUnmodifiableListView) return _remove;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
+}
 
-  final Map<String, EntityDiff>? _change;
-  @override
-  @JsonKey(name: 'c')
-  Map<String, EntityDiff>? get change {
-    final value = _change;
-    if (value == null) return null;
-    if (_change is EqualUnmodifiableMapView) return _change;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableMapView(value);
-  }
+ final  Map<String, EntityDiff>? _change;
+@override@JsonKey(name: 'c') Map<String, EntityDiff>? get change {
+  final value = _change;
+  if (value == null) return null;
+  if (_change is EqualUnmodifiableMapView) return _change;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(value);
+}
 
-  /// Create a copy of StatesUpdates
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$StatesUpdatesCopyWith<_StatesUpdates> get copyWith =>
-      __$StatesUpdatesCopyWithImpl<_StatesUpdates>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$StatesUpdatesToJson(
-      this,
-    );
-  }
+/// Create a copy of StatesUpdates
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$StatesUpdatesCopyWith<_StatesUpdates> get copyWith => __$StatesUpdatesCopyWithImpl<_StatesUpdates>(this, _$identity);
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _StatesUpdates &&
-            const DeepCollectionEquality().equals(other._add, _add) &&
-            const DeepCollectionEquality().equals(other._remove, _remove) &&
-            const DeepCollectionEquality().equals(other._change, _change));
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$StatesUpdatesToJson(this, );
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(_add),
-      const DeepCollectionEquality().hash(_remove),
-      const DeepCollectionEquality().hash(_change));
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _StatesUpdates&&const DeepCollectionEquality().equals(other._add, _add)&&const DeepCollectionEquality().equals(other._remove, _remove)&&const DeepCollectionEquality().equals(other._change, _change));
+}
 
-  @override
-  String toString() {
-    return 'StatesUpdates(add: $add, remove: $remove, change: $change)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_add),const DeepCollectionEquality().hash(_remove),const DeepCollectionEquality().hash(_change));
+
+@override
+String toString() {
+  return 'StatesUpdates(add: $add, remove: $remove, change: $change)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class _$StatesUpdatesCopyWith<$Res>
-    implements $StatesUpdatesCopyWith<$Res> {
-  factory _$StatesUpdatesCopyWith(
-          _StatesUpdates value, $Res Function(_StatesUpdates) _then) =
-      __$StatesUpdatesCopyWithImpl;
-  @override
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'a') Map<String, EntityState>? add,
-      @JsonKey(name: 'r') List<String>? remove,
-      @JsonKey(name: 'c') Map<String, EntityDiff>? change});
-}
+abstract mixin class _$StatesUpdatesCopyWith<$Res> implements $StatesUpdatesCopyWith<$Res> {
+  factory _$StatesUpdatesCopyWith(_StatesUpdates value, $Res Function(_StatesUpdates) _then) = __$StatesUpdatesCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'a') Map<String, EntityState>? add,@JsonKey(name: 'r') List<String>? remove,@JsonKey(name: 'c') Map<String, EntityDiff>? change
+});
 
+
+
+
+}
 /// @nodoc
 class __$StatesUpdatesCopyWithImpl<$Res>
     implements _$StatesUpdatesCopyWith<$Res> {
@@ -1525,79 +1156,64 @@ class __$StatesUpdatesCopyWithImpl<$Res>
   final _StatesUpdates _self;
   final $Res Function(_StatesUpdates) _then;
 
-  /// Create a copy of StatesUpdates
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? add = freezed,
-    Object? remove = freezed,
-    Object? change = freezed,
-  }) {
-    return _then(_StatesUpdates(
-      add: freezed == add
-          ? _self._add
-          : add // ignore: cast_nullable_to_non_nullable
-              as Map<String, EntityState>?,
-      remove: freezed == remove
-          ? _self._remove
-          : remove // ignore: cast_nullable_to_non_nullable
-              as List<String>?,
-      change: freezed == change
-          ? _self._change
-          : change // ignore: cast_nullable_to_non_nullable
-              as Map<String, EntityDiff>?,
-    ));
-  }
+/// Create a copy of StatesUpdates
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? add = freezed,Object? remove = freezed,Object? change = freezed,}) {
+  return _then(_StatesUpdates(
+add: freezed == add ? _self._add : add // ignore: cast_nullable_to_non_nullable
+as Map<String, EntityState>?,remove: freezed == remove ? _self._remove : remove // ignore: cast_nullable_to_non_nullable
+as List<String>?,change: freezed == change ? _self._change : change // ignore: cast_nullable_to_non_nullable
+as Map<String, EntityDiff>?,
+  ));
 }
+
+
+}
+
 
 /// @nodoc
 mixin _$CallServiceResponse {
-  Context get context;
-  dynamic get response;
 
-  /// Create a copy of CallServiceResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $CallServiceResponseCopyWith<CallServiceResponse> get copyWith =>
-      _$CallServiceResponseCopyWithImpl<CallServiceResponse>(
-          this as CallServiceResponse, _$identity);
+ Context get context; dynamic get response;
+/// Create a copy of CallServiceResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CallServiceResponseCopyWith<CallServiceResponse> get copyWith => _$CallServiceResponseCopyWithImpl<CallServiceResponse>(this as CallServiceResponse, _$identity);
 
   /// Serializes this CallServiceResponse to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is CallServiceResponse &&
-            (identical(other.context, context) || other.context == context) &&
-            const DeepCollectionEquality().equals(other.response, response));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType, context, const DeepCollectionEquality().hash(response));
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CallServiceResponse&&(identical(other.context, context) || other.context == context)&&const DeepCollectionEquality().equals(other.response, response));
+}
 
-  @override
-  String toString() {
-    return 'CallServiceResponse(context: $context, response: $response)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,context,const DeepCollectionEquality().hash(response));
+
+@override
+String toString() {
+  return 'CallServiceResponse(context: $context, response: $response)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $CallServiceResponseCopyWith<$Res> {
-  factory $CallServiceResponseCopyWith(
-          CallServiceResponse value, $Res Function(CallServiceResponse) _then) =
-      _$CallServiceResponseCopyWithImpl;
-  @useResult
-  $Res call({Context context, dynamic response});
+abstract mixin class $CallServiceResponseCopyWith<$Res>  {
+  factory $CallServiceResponseCopyWith(CallServiceResponse value, $Res Function(CallServiceResponse) _then) = _$CallServiceResponseCopyWithImpl;
+@useResult
+$Res call({
+ Context context, dynamic response
+});
 
-  $ContextCopyWith<$Res> get context;
+
+$ContextCopyWith<$Res> get context;
+
 }
-
 /// @nodoc
 class _$CallServiceResponseCopyWithImpl<$Res>
     implements $CallServiceResponseCopyWith<$Res> {
@@ -1606,252 +1222,202 @@ class _$CallServiceResponseCopyWithImpl<$Res>
   final CallServiceResponse _self;
   final $Res Function(CallServiceResponse) _then;
 
-  /// Create a copy of CallServiceResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? context = null,
-    Object? response = freezed,
-  }) {
-    return _then(_self.copyWith(
-      context: null == context
-          ? _self.context
-          : context // ignore: cast_nullable_to_non_nullable
-              as Context,
-      response: freezed == response
-          ? _self.response
-          : response // ignore: cast_nullable_to_non_nullable
-              as dynamic,
-    ));
-  }
-
-  /// Create a copy of CallServiceResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $ContextCopyWith<$Res> get context {
-    return $ContextCopyWith<$Res>(_self.context, (value) {
-      return _then(_self.copyWith(context: value));
-    });
-  }
+/// Create a copy of CallServiceResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? context = null,Object? response = freezed,}) {
+  return _then(_self.copyWith(
+context: null == context ? _self.context : context // ignore: cast_nullable_to_non_nullable
+as Context,response: freezed == response ? _self.response : response // ignore: cast_nullable_to_non_nullable
+as dynamic,
+  ));
 }
+/// Create a copy of CallServiceResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$ContextCopyWith<$Res> get context {
+  
+  return $ContextCopyWith<$Res>(_self.context, (value) {
+    return _then(_self.copyWith(context: value));
+  });
+}
+}
+
 
 /// Adds pattern-matching-related methods to [CallServiceResponse].
 extension CallServiceResponsePatterns on CallServiceResponse {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_CallServiceResponse value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _CallServiceResponse() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _CallServiceResponse value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _CallServiceResponse() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_CallServiceResponse value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _CallServiceResponse():
-        return $default(_that);
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _CallServiceResponse value)  $default,){
+final _that = this;
+switch (_that) {
+case _CallServiceResponse():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _CallServiceResponse value)?  $default,){
+final _that = this;
+switch (_that) {
+case _CallServiceResponse() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_CallServiceResponse value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _CallServiceResponse() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( Context context,  dynamic response)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _CallServiceResponse() when $default != null:
+return $default(_that.context,_that.response);case _:
+  return orElse();
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(Context context, dynamic response)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _CallServiceResponse() when $default != null:
-        return $default(_that.context, _that.response);
-      case _:
-        return orElse();
-    }
-  }
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( Context context,  dynamic response)  $default,) {final _that = this;
+switch (_that) {
+case _CallServiceResponse():
+return $default(_that.context,_that.response);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(Context context, dynamic response) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _CallServiceResponse():
-        return $default(_that.context, _that.response);
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( Context context,  dynamic response)?  $default,) {final _that = this;
+switch (_that) {
+case _CallServiceResponse() when $default != null:
+return $default(_that.context,_that.response);case _:
+  return null;
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(Context context, dynamic response)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _CallServiceResponse() when $default != null:
-        return $default(_that.context, _that.response);
-      case _:
-        return null;
-    }
-  }
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _CallServiceResponse implements CallServiceResponse {
-  _CallServiceResponse({required this.context, this.response});
-  factory _CallServiceResponse.fromJson(Map<String, dynamic> json) =>
-      _$CallServiceResponseFromJson(json);
+   _CallServiceResponse({required this.context, this.response});
+  factory _CallServiceResponse.fromJson(Map<String, dynamic> json) => _$CallServiceResponseFromJson(json);
 
-  @override
-  final Context context;
-  @override
-  final dynamic response;
+@override final  Context context;
+@override final  dynamic response;
 
-  /// Create a copy of CallServiceResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$CallServiceResponseCopyWith<_CallServiceResponse> get copyWith =>
-      __$CallServiceResponseCopyWithImpl<_CallServiceResponse>(
-          this, _$identity);
+/// Create a copy of CallServiceResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$CallServiceResponseCopyWith<_CallServiceResponse> get copyWith => __$CallServiceResponseCopyWithImpl<_CallServiceResponse>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$CallServiceResponseToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$CallServiceResponseToJson(this, );
+}
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _CallServiceResponse &&
-            (identical(other.context, context) || other.context == context) &&
-            const DeepCollectionEquality().equals(other.response, response));
-  }
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CallServiceResponse&&(identical(other.context, context) || other.context == context)&&const DeepCollectionEquality().equals(other.response, response));
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType, context, const DeepCollectionEquality().hash(response));
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,context,const DeepCollectionEquality().hash(response));
 
-  @override
-  String toString() {
-    return 'CallServiceResponse(context: $context, response: $response)';
-  }
+@override
+String toString() {
+  return 'CallServiceResponse(context: $context, response: $response)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class _$CallServiceResponseCopyWith<$Res>
-    implements $CallServiceResponseCopyWith<$Res> {
-  factory _$CallServiceResponseCopyWith(_CallServiceResponse value,
-          $Res Function(_CallServiceResponse) _then) =
-      __$CallServiceResponseCopyWithImpl;
-  @override
-  @useResult
-  $Res call({Context context, dynamic response});
+abstract mixin class _$CallServiceResponseCopyWith<$Res> implements $CallServiceResponseCopyWith<$Res> {
+  factory _$CallServiceResponseCopyWith(_CallServiceResponse value, $Res Function(_CallServiceResponse) _then) = __$CallServiceResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ Context context, dynamic response
+});
 
-  @override
-  $ContextCopyWith<$Res> get context;
+
+@override $ContextCopyWith<$Res> get context;
+
 }
-
 /// @nodoc
 class __$CallServiceResponseCopyWithImpl<$Res>
     implements _$CallServiceResponseCopyWith<$Res> {
@@ -1860,405 +1426,332 @@ class __$CallServiceResponseCopyWithImpl<$Res>
   final _CallServiceResponse _self;
   final $Res Function(_CallServiceResponse) _then;
 
-  /// Create a copy of CallServiceResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? context = null,
-    Object? response = freezed,
-  }) {
-    return _then(_CallServiceResponse(
-      context: null == context
-          ? _self.context
-          : context // ignore: cast_nullable_to_non_nullable
-              as Context,
-      response: freezed == response
-          ? _self.response
-          : response // ignore: cast_nullable_to_non_nullable
-              as dynamic,
-    ));
-  }
-
-  /// Create a copy of CallServiceResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $ContextCopyWith<$Res> get context {
-    return $ContextCopyWith<$Res>(_self.context, (value) {
-      return _then(_self.copyWith(context: value));
-    });
-  }
+/// Create a copy of CallServiceResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? context = null,Object? response = freezed,}) {
+  return _then(_CallServiceResponse(
+context: null == context ? _self.context : context // ignore: cast_nullable_to_non_nullable
+as Context,response: freezed == response ? _self.response : response // ignore: cast_nullable_to_non_nullable
+as dynamic,
+  ));
 }
+
+/// Create a copy of CallServiceResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$ContextCopyWith<$Res> get context {
+  
+  return $ContextCopyWith<$Res>(_self.context, (value) {
+    return _then(_self.copyWith(context: value));
+  });
+}
+}
+
 
 /// @nodoc
 mixin _$Context {
-  String get id;
-  String? get user_id;
-  String? get parent_id;
 
-  /// Create a copy of Context
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $ContextCopyWith<Context> get copyWith =>
-      _$ContextCopyWithImpl<Context>(this as Context, _$identity);
+ String get id; String? get user_id; String? get parent_id;
+/// Create a copy of Context
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ContextCopyWith<Context> get copyWith => _$ContextCopyWithImpl<Context>(this as Context, _$identity);
 
   /// Serializes this Context to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is Context &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.user_id, user_id) || other.user_id == user_id) &&
-            (identical(other.parent_id, parent_id) ||
-                other.parent_id == parent_id));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(runtimeType, id, user_id, parent_id);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Context&&(identical(other.id, id) || other.id == id)&&(identical(other.user_id, user_id) || other.user_id == user_id)&&(identical(other.parent_id, parent_id) || other.parent_id == parent_id));
+}
 
-  @override
-  String toString() {
-    return 'Context(id: $id, user_id: $user_id, parent_id: $parent_id)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,user_id,parent_id);
+
+@override
+String toString() {
+  return 'Context(id: $id, user_id: $user_id, parent_id: $parent_id)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $ContextCopyWith<$Res> {
-  factory $ContextCopyWith(Context value, $Res Function(Context) _then) =
-      _$ContextCopyWithImpl;
-  @useResult
-  $Res call({String id, String? user_id, String? parent_id});
-}
+abstract mixin class $ContextCopyWith<$Res>  {
+  factory $ContextCopyWith(Context value, $Res Function(Context) _then) = _$ContextCopyWithImpl;
+@useResult
+$Res call({
+ String id, String? user_id, String? parent_id
+});
 
+
+
+
+}
 /// @nodoc
-class _$ContextCopyWithImpl<$Res> implements $ContextCopyWith<$Res> {
+class _$ContextCopyWithImpl<$Res>
+    implements $ContextCopyWith<$Res> {
   _$ContextCopyWithImpl(this._self, this._then);
 
   final Context _self;
   final $Res Function(Context) _then;
 
-  /// Create a copy of Context
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? id = null,
-    Object? user_id = freezed,
-    Object? parent_id = freezed,
-  }) {
-    return _then(_self.copyWith(
-      id: null == id
-          ? _self.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      user_id: freezed == user_id
-          ? _self.user_id
-          : user_id // ignore: cast_nullable_to_non_nullable
-              as String?,
-      parent_id: freezed == parent_id
-          ? _self.parent_id
-          : parent_id // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ));
-  }
+/// Create a copy of Context
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? user_id = freezed,Object? parent_id = freezed,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,user_id: freezed == user_id ? _self.user_id : user_id // ignore: cast_nullable_to_non_nullable
+as String?,parent_id: freezed == parent_id ? _self.parent_id : parent_id // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
 }
+
+}
+
 
 /// Adds pattern-matching-related methods to [Context].
 extension ContextPatterns on Context {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_Context value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _Context() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Context value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Context() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_Context value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _Context():
-        return $default(_that);
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Context value)  $default,){
+final _that = this;
+switch (_that) {
+case _Context():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Context value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Context() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_Context value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _Context() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String? user_id,  String? parent_id)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Context() when $default != null:
+return $default(_that.id,_that.user_id,_that.parent_id);case _:
+  return orElse();
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(String id, String? user_id, String? parent_id)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _Context() when $default != null:
-        return $default(_that.id, _that.user_id, _that.parent_id);
-      case _:
-        return orElse();
-    }
-  }
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String? user_id,  String? parent_id)  $default,) {final _that = this;
+switch (_that) {
+case _Context():
+return $default(_that.id,_that.user_id,_that.parent_id);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(String id, String? user_id, String? parent_id) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _Context():
-        return $default(_that.id, _that.user_id, _that.parent_id);
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String? user_id,  String? parent_id)?  $default,) {final _that = this;
+switch (_that) {
+case _Context() when $default != null:
+return $default(_that.id,_that.user_id,_that.parent_id);case _:
+  return null;
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(String id, String? user_id, String? parent_id)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _Context() when $default != null:
-        return $default(_that.id, _that.user_id, _that.parent_id);
-      case _:
-        return null;
-    }
-  }
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _Context implements Context {
   const _Context({required this.id, this.user_id, this.parent_id});
-  factory _Context.fromJson(Map<String, dynamic> json) =>
-      _$ContextFromJson(json);
+  factory _Context.fromJson(Map<String, dynamic> json) => _$ContextFromJson(json);
 
-  @override
-  final String id;
-  @override
-  final String? user_id;
-  @override
-  final String? parent_id;
+@override final  String id;
+@override final  String? user_id;
+@override final  String? parent_id;
 
-  /// Create a copy of Context
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$ContextCopyWith<_Context> get copyWith =>
-      __$ContextCopyWithImpl<_Context>(this, _$identity);
+/// Create a copy of Context
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ContextCopyWith<_Context> get copyWith => __$ContextCopyWithImpl<_Context>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$ContextToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$ContextToJson(this, );
+}
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _Context &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.user_id, user_id) || other.user_id == user_id) &&
-            (identical(other.parent_id, parent_id) ||
-                other.parent_id == parent_id));
-  }
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Context&&(identical(other.id, id) || other.id == id)&&(identical(other.user_id, user_id) || other.user_id == user_id)&&(identical(other.parent_id, parent_id) || other.parent_id == parent_id));
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(runtimeType, id, user_id, parent_id);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,user_id,parent_id);
 
-  @override
-  String toString() {
-    return 'Context(id: $id, user_id: $user_id, parent_id: $parent_id)';
-  }
+@override
+String toString() {
+  return 'Context(id: $id, user_id: $user_id, parent_id: $parent_id)';
+}
+
+
 }
 
 /// @nodoc
 abstract mixin class _$ContextCopyWith<$Res> implements $ContextCopyWith<$Res> {
-  factory _$ContextCopyWith(_Context value, $Res Function(_Context) _then) =
-      __$ContextCopyWithImpl;
-  @override
-  @useResult
-  $Res call({String id, String? user_id, String? parent_id});
-}
+  factory _$ContextCopyWith(_Context value, $Res Function(_Context) _then) = __$ContextCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, String? user_id, String? parent_id
+});
 
+
+
+
+}
 /// @nodoc
-class __$ContextCopyWithImpl<$Res> implements _$ContextCopyWith<$Res> {
+class __$ContextCopyWithImpl<$Res>
+    implements _$ContextCopyWith<$Res> {
   __$ContextCopyWithImpl(this._self, this._then);
 
   final _Context _self;
   final $Res Function(_Context) _then;
 
-  /// Create a copy of Context
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? id = null,
-    Object? user_id = freezed,
-    Object? parent_id = freezed,
-  }) {
-    return _then(_Context(
-      id: null == id
-          ? _self.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      user_id: freezed == user_id
-          ? _self.user_id
-          : user_id // ignore: cast_nullable_to_non_nullable
-              as String?,
-      parent_id: freezed == parent_id
-          ? _self.parent_id
-          : parent_id // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ));
-  }
+/// Create a copy of Context
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? user_id = freezed,Object? parent_id = freezed,}) {
+  return _then(_Context(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,user_id: freezed == user_id ? _self.user_id : user_id // ignore: cast_nullable_to_non_nullable
+as String?,parent_id: freezed == parent_id ? _self.parent_id : parent_id // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
 }
 
 /// @nodoc
 mixin _$HassEventBase {
-  Context get context;
-  String get origin;
-  String get timeFired;
 
-  /// Create a copy of HassEventBase
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $HassEventBaseCopyWith<HassEventBase> get copyWith =>
-      _$HassEventBaseCopyWithImpl<HassEventBase>(
-          this as HassEventBase, _$identity);
+ Context get context; String get origin; String get timeFired;
+/// Create a copy of HassEventBase
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$HassEventBaseCopyWith<HassEventBase> get copyWith => _$HassEventBaseCopyWithImpl<HassEventBase>(this as HassEventBase, _$identity);
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is HassEventBase &&
-            (identical(other.context, context) || other.context == context) &&
-            (identical(other.origin, origin) || other.origin == origin) &&
-            (identical(other.timeFired, timeFired) ||
-                other.timeFired == timeFired));
-  }
 
-  @override
-  int get hashCode => Object.hash(runtimeType, context, origin, timeFired);
 
-  @override
-  String toString() {
-    return 'HassEventBase(context: $context, origin: $origin, timeFired: $timeFired)';
-  }
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is HassEventBase&&(identical(other.context, context) || other.context == context)&&(identical(other.origin, origin) || other.origin == origin)&&(identical(other.timeFired, timeFired) || other.timeFired == timeFired));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,context,origin,timeFired);
+
+@override
+String toString() {
+  return 'HassEventBase(context: $context, origin: $origin, timeFired: $timeFired)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $HassEventBaseCopyWith<$Res> {
-  factory $HassEventBaseCopyWith(
-          HassEventBase value, $Res Function(HassEventBase) _then) =
-      _$HassEventBaseCopyWithImpl;
-  @useResult
-  $Res call({Context context, String origin, String timeFired});
+abstract mixin class $HassEventBaseCopyWith<$Res>  {
+  factory $HassEventBaseCopyWith(HassEventBase value, $Res Function(HassEventBase) _then) = _$HassEventBaseCopyWithImpl;
+@useResult
+$Res call({
+ Context context, String origin, String timeFired
+});
 
-  $ContextCopyWith<$Res> get context;
+
+$ContextCopyWith<$Res> get context;
+
 }
-
 /// @nodoc
 class _$HassEventBaseCopyWithImpl<$Res>
     implements $HassEventBaseCopyWith<$Res> {
@@ -2267,256 +1760,207 @@ class _$HassEventBaseCopyWithImpl<$Res>
   final HassEventBase _self;
   final $Res Function(HassEventBase) _then;
 
-  /// Create a copy of HassEventBase
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? context = null,
-    Object? origin = null,
-    Object? timeFired = null,
-  }) {
-    return _then(_self.copyWith(
-      context: null == context
-          ? _self.context
-          : context // ignore: cast_nullable_to_non_nullable
-              as Context,
-      origin: null == origin
-          ? _self.origin
-          : origin // ignore: cast_nullable_to_non_nullable
-              as String,
-      timeFired: null == timeFired
-          ? _self.timeFired
-          : timeFired // ignore: cast_nullable_to_non_nullable
-              as String,
-    ));
-  }
-
-  /// Create a copy of HassEventBase
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $ContextCopyWith<$Res> get context {
-    return $ContextCopyWith<$Res>(_self.context, (value) {
-      return _then(_self.copyWith(context: value));
-    });
-  }
+/// Create a copy of HassEventBase
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? context = null,Object? origin = null,Object? timeFired = null,}) {
+  return _then(_self.copyWith(
+context: null == context ? _self.context : context // ignore: cast_nullable_to_non_nullable
+as Context,origin: null == origin ? _self.origin : origin // ignore: cast_nullable_to_non_nullable
+as String,timeFired: null == timeFired ? _self.timeFired : timeFired // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
 }
+/// Create a copy of HassEventBase
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$ContextCopyWith<$Res> get context {
+  
+  return $ContextCopyWith<$Res>(_self.context, (value) {
+    return _then(_self.copyWith(context: value));
+  });
+}
+}
+
 
 /// Adds pattern-matching-related methods to [HassEventBase].
 extension HassEventBasePatterns on HassEventBase {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_HassEventBase value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _HassEventBase() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _HassEventBase value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _HassEventBase() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_HassEventBase value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _HassEventBase():
-        return $default(_that);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _HassEventBase value)  $default,){
+final _that = this;
+switch (_that) {
+case _HassEventBase():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_HassEventBase value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _HassEventBase() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _HassEventBase value)?  $default,){
+final _that = this;
+switch (_that) {
+case _HassEventBase() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(Context context, String origin, String timeFired)?
-        $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _HassEventBase() when $default != null:
-        return $default(_that.context, _that.origin, _that.timeFired);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( Context context,  String origin,  String timeFired)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _HassEventBase() when $default != null:
+return $default(_that.context,_that.origin,_that.timeFired);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(Context context, String origin, String timeFired) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _HassEventBase():
-        return $default(_that.context, _that.origin, _that.timeFired);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( Context context,  String origin,  String timeFired)  $default,) {final _that = this;
+switch (_that) {
+case _HassEventBase():
+return $default(_that.context,_that.origin,_that.timeFired);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(Context context, String origin, String timeFired)?
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _HassEventBase() when $default != null:
-        return $default(_that.context, _that.origin, _that.timeFired);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( Context context,  String origin,  String timeFired)?  $default,) {final _that = this;
+switch (_that) {
+case _HassEventBase() when $default != null:
+return $default(_that.context,_that.origin,_that.timeFired);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
+
 
 class _HassEventBase implements HassEventBase {
-  const _HassEventBase(
-      {required this.context, required this.origin, required this.timeFired});
+  const _HassEventBase({required this.context, required this.origin, required this.timeFired});
+  
 
-  @override
-  final Context context;
-  @override
-  final String origin;
-  @override
-  final String timeFired;
+@override final  Context context;
+@override final  String origin;
+@override final  String timeFired;
 
-  /// Create a copy of HassEventBase
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$HassEventBaseCopyWith<_HassEventBase> get copyWith =>
-      __$HassEventBaseCopyWithImpl<_HassEventBase>(this, _$identity);
+/// Create a copy of HassEventBase
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$HassEventBaseCopyWith<_HassEventBase> get copyWith => __$HassEventBaseCopyWithImpl<_HassEventBase>(this, _$identity);
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _HassEventBase &&
-            (identical(other.context, context) || other.context == context) &&
-            (identical(other.origin, origin) || other.origin == origin) &&
-            (identical(other.timeFired, timeFired) ||
-                other.timeFired == timeFired));
-  }
 
-  @override
-  int get hashCode => Object.hash(runtimeType, context, origin, timeFired);
 
-  @override
-  String toString() {
-    return 'HassEventBase(context: $context, origin: $origin, timeFired: $timeFired)';
-  }
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _HassEventBase&&(identical(other.context, context) || other.context == context)&&(identical(other.origin, origin) || other.origin == origin)&&(identical(other.timeFired, timeFired) || other.timeFired == timeFired));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,context,origin,timeFired);
+
+@override
+String toString() {
+  return 'HassEventBase(context: $context, origin: $origin, timeFired: $timeFired)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class _$HassEventBaseCopyWith<$Res>
-    implements $HassEventBaseCopyWith<$Res> {
-  factory _$HassEventBaseCopyWith(
-          _HassEventBase value, $Res Function(_HassEventBase) _then) =
-      __$HassEventBaseCopyWithImpl;
-  @override
-  @useResult
-  $Res call({Context context, String origin, String timeFired});
+abstract mixin class _$HassEventBaseCopyWith<$Res> implements $HassEventBaseCopyWith<$Res> {
+  factory _$HassEventBaseCopyWith(_HassEventBase value, $Res Function(_HassEventBase) _then) = __$HassEventBaseCopyWithImpl;
+@override @useResult
+$Res call({
+ Context context, String origin, String timeFired
+});
 
-  @override
-  $ContextCopyWith<$Res> get context;
+
+@override $ContextCopyWith<$Res> get context;
+
 }
-
 /// @nodoc
 class __$HassEventBaseCopyWithImpl<$Res>
     implements _$HassEventBaseCopyWith<$Res> {
@@ -2525,1014 +1969,674 @@ class __$HassEventBaseCopyWithImpl<$Res>
   final _HassEventBase _self;
   final $Res Function(_HassEventBase) _then;
 
-  /// Create a copy of HassEventBase
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? context = null,
-    Object? origin = null,
-    Object? timeFired = null,
-  }) {
-    return _then(_HassEventBase(
-      context: null == context
-          ? _self.context
-          : context // ignore: cast_nullable_to_non_nullable
-              as Context,
-      origin: null == origin
-          ? _self.origin
-          : origin // ignore: cast_nullable_to_non_nullable
-              as String,
-      timeFired: null == timeFired
-          ? _self.timeFired
-          : timeFired // ignore: cast_nullable_to_non_nullable
-              as String,
-    ));
-  }
-
-  /// Create a copy of HassEventBase
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $ContextCopyWith<$Res> get context {
-    return $ContextCopyWith<$Res>(_self.context, (value) {
-      return _then(_self.copyWith(context: value));
-    });
-  }
+/// Create a copy of HassEventBase
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? context = null,Object? origin = null,Object? timeFired = null,}) {
+  return _then(_HassEventBase(
+context: null == context ? _self.context : context // ignore: cast_nullable_to_non_nullable
+as Context,origin: null == origin ? _self.origin : origin // ignore: cast_nullable_to_non_nullable
+as String,timeFired: null == timeFired ? _self.timeFired : timeFired // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
 }
+
+/// Create a copy of HassEventBase
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$ContextCopyWith<$Res> get context {
+  
+  return $ContextCopyWith<$Res>(_self.context, (value) {
+    return _then(_self.copyWith(context: value));
+  });
+}
+}
+
 
 /// @nodoc
 mixin _$HassEvent {
-  Context get context;
-  String get origin;
-  String get timeFired;
-  String get eventType;
-  Map<String, dynamic> get data;
 
-  /// Create a copy of HassEvent
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $HassEventCopyWith<HassEvent> get copyWith =>
-      _$HassEventCopyWithImpl<HassEvent>(this as HassEvent, _$identity);
+ Context get context; String get origin; String get timeFired; String get eventType; Map<String, dynamic> get data;
+/// Create a copy of HassEvent
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$HassEventCopyWith<HassEvent> get copyWith => _$HassEventCopyWithImpl<HassEvent>(this as HassEvent, _$identity);
 
   /// Serializes this HassEvent to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is HassEvent &&
-            (identical(other.context, context) || other.context == context) &&
-            (identical(other.origin, origin) || other.origin == origin) &&
-            (identical(other.timeFired, timeFired) ||
-                other.timeFired == timeFired) &&
-            (identical(other.eventType, eventType) ||
-                other.eventType == eventType) &&
-            const DeepCollectionEquality().equals(other.data, data));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(runtimeType, context, origin, timeFired,
-      eventType, const DeepCollectionEquality().hash(data));
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is HassEvent&&(identical(other.context, context) || other.context == context)&&(identical(other.origin, origin) || other.origin == origin)&&(identical(other.timeFired, timeFired) || other.timeFired == timeFired)&&(identical(other.eventType, eventType) || other.eventType == eventType)&&const DeepCollectionEquality().equals(other.data, data));
+}
 
-  @override
-  String toString() {
-    return 'HassEvent(context: $context, origin: $origin, timeFired: $timeFired, eventType: $eventType, data: $data)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,context,origin,timeFired,eventType,const DeepCollectionEquality().hash(data));
+
+@override
+String toString() {
+  return 'HassEvent(context: $context, origin: $origin, timeFired: $timeFired, eventType: $eventType, data: $data)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $HassEventCopyWith<$Res> {
-  factory $HassEventCopyWith(HassEvent value, $Res Function(HassEvent) _then) =
-      _$HassEventCopyWithImpl;
-  @useResult
-  $Res call(
-      {Context context,
-      String origin,
-      String timeFired,
-      String eventType,
-      Map<String, dynamic> data});
+abstract mixin class $HassEventCopyWith<$Res>  {
+  factory $HassEventCopyWith(HassEvent value, $Res Function(HassEvent) _then) = _$HassEventCopyWithImpl;
+@useResult
+$Res call({
+ Context context, String origin, String timeFired, String eventType, Map<String, dynamic> data
+});
 
-  $ContextCopyWith<$Res> get context;
+
+$ContextCopyWith<$Res> get context;
+
 }
-
 /// @nodoc
-class _$HassEventCopyWithImpl<$Res> implements $HassEventCopyWith<$Res> {
+class _$HassEventCopyWithImpl<$Res>
+    implements $HassEventCopyWith<$Res> {
   _$HassEventCopyWithImpl(this._self, this._then);
 
   final HassEvent _self;
   final $Res Function(HassEvent) _then;
 
-  /// Create a copy of HassEvent
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? context = null,
-    Object? origin = null,
-    Object? timeFired = null,
-    Object? eventType = null,
-    Object? data = null,
-  }) {
-    return _then(_self.copyWith(
-      context: null == context
-          ? _self.context
-          : context // ignore: cast_nullable_to_non_nullable
-              as Context,
-      origin: null == origin
-          ? _self.origin
-          : origin // ignore: cast_nullable_to_non_nullable
-              as String,
-      timeFired: null == timeFired
-          ? _self.timeFired
-          : timeFired // ignore: cast_nullable_to_non_nullable
-              as String,
-      eventType: null == eventType
-          ? _self.eventType
-          : eventType // ignore: cast_nullable_to_non_nullable
-              as String,
-      data: null == data
-          ? _self.data
-          : data // ignore: cast_nullable_to_non_nullable
-              as Map<String, dynamic>,
-    ));
-  }
-
-  /// Create a copy of HassEvent
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $ContextCopyWith<$Res> get context {
-    return $ContextCopyWith<$Res>(_self.context, (value) {
-      return _then(_self.copyWith(context: value));
-    });
-  }
+/// Create a copy of HassEvent
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? context = null,Object? origin = null,Object? timeFired = null,Object? eventType = null,Object? data = null,}) {
+  return _then(_self.copyWith(
+context: null == context ? _self.context : context // ignore: cast_nullable_to_non_nullable
+as Context,origin: null == origin ? _self.origin : origin // ignore: cast_nullable_to_non_nullable
+as String,timeFired: null == timeFired ? _self.timeFired : timeFired // ignore: cast_nullable_to_non_nullable
+as String,eventType: null == eventType ? _self.eventType : eventType // ignore: cast_nullable_to_non_nullable
+as String,data: null == data ? _self.data : data // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>,
+  ));
 }
+/// Create a copy of HassEvent
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$ContextCopyWith<$Res> get context {
+  
+  return $ContextCopyWith<$Res>(_self.context, (value) {
+    return _then(_self.copyWith(context: value));
+  });
+}
+}
+
 
 /// Adds pattern-matching-related methods to [HassEvent].
 extension HassEventPatterns on HassEvent {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_HassEvent value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _HassEvent() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _HassEvent value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _HassEvent() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_HassEvent value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _HassEvent():
-        return $default(_that);
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _HassEvent value)  $default,){
+final _that = this;
+switch (_that) {
+case _HassEvent():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _HassEvent value)?  $default,){
+final _that = this;
+switch (_that) {
+case _HassEvent() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_HassEvent value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _HassEvent() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( Context context,  String origin,  String timeFired,  String eventType,  Map<String, dynamic> data)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _HassEvent() when $default != null:
+return $default(_that.context,_that.origin,_that.timeFired,_that.eventType,_that.data);case _:
+  return orElse();
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(Context context, String origin, String timeFired,
-            String eventType, Map<String, dynamic> data)?
-        $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _HassEvent() when $default != null:
-        return $default(_that.context, _that.origin, _that.timeFired,
-            _that.eventType, _that.data);
-      case _:
-        return orElse();
-    }
-  }
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( Context context,  String origin,  String timeFired,  String eventType,  Map<String, dynamic> data)  $default,) {final _that = this;
+switch (_that) {
+case _HassEvent():
+return $default(_that.context,_that.origin,_that.timeFired,_that.eventType,_that.data);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(Context context, String origin, String timeFired,
-            String eventType, Map<String, dynamic> data)
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _HassEvent():
-        return $default(_that.context, _that.origin, _that.timeFired,
-            _that.eventType, _that.data);
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( Context context,  String origin,  String timeFired,  String eventType,  Map<String, dynamic> data)?  $default,) {final _that = this;
+switch (_that) {
+case _HassEvent() when $default != null:
+return $default(_that.context,_that.origin,_that.timeFired,_that.eventType,_that.data);case _:
+  return null;
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(Context context, String origin, String timeFired,
-            String eventType, Map<String, dynamic> data)?
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _HassEvent() when $default != null:
-        return $default(_that.context, _that.origin, _that.timeFired,
-            _that.eventType, _that.data);
-      case _:
-        return null;
-    }
-  }
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _HassEvent implements HassEvent {
-  _HassEvent(
-      {required this.context,
-      required this.origin,
-      required this.timeFired,
-      required this.eventType,
-      required final Map<String, dynamic> data})
-      : _data = data;
-  factory _HassEvent.fromJson(Map<String, dynamic> json) =>
-      _$HassEventFromJson(json);
+   _HassEvent({required this.context, required this.origin, required this.timeFired, required this.eventType, required final  Map<String, dynamic> data}): _data = data;
+  factory _HassEvent.fromJson(Map<String, dynamic> json) => _$HassEventFromJson(json);
 
-  @override
-  final Context context;
-  @override
-  final String origin;
-  @override
-  final String timeFired;
-  @override
-  final String eventType;
-  final Map<String, dynamic> _data;
-  @override
-  Map<String, dynamic> get data {
-    if (_data is EqualUnmodifiableMapView) return _data;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableMapView(_data);
-  }
+@override final  Context context;
+@override final  String origin;
+@override final  String timeFired;
+@override final  String eventType;
+ final  Map<String, dynamic> _data;
+@override Map<String, dynamic> get data {
+  if (_data is EqualUnmodifiableMapView) return _data;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(_data);
+}
 
-  /// Create a copy of HassEvent
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$HassEventCopyWith<_HassEvent> get copyWith =>
-      __$HassEventCopyWithImpl<_HassEvent>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$HassEventToJson(
-      this,
-    );
-  }
+/// Create a copy of HassEvent
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$HassEventCopyWith<_HassEvent> get copyWith => __$HassEventCopyWithImpl<_HassEvent>(this, _$identity);
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _HassEvent &&
-            (identical(other.context, context) || other.context == context) &&
-            (identical(other.origin, origin) || other.origin == origin) &&
-            (identical(other.timeFired, timeFired) ||
-                other.timeFired == timeFired) &&
-            (identical(other.eventType, eventType) ||
-                other.eventType == eventType) &&
-            const DeepCollectionEquality().equals(other._data, _data));
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$HassEventToJson(this, );
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(runtimeType, context, origin, timeFired,
-      eventType, const DeepCollectionEquality().hash(_data));
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _HassEvent&&(identical(other.context, context) || other.context == context)&&(identical(other.origin, origin) || other.origin == origin)&&(identical(other.timeFired, timeFired) || other.timeFired == timeFired)&&(identical(other.eventType, eventType) || other.eventType == eventType)&&const DeepCollectionEquality().equals(other._data, _data));
+}
 
-  @override
-  String toString() {
-    return 'HassEvent(context: $context, origin: $origin, timeFired: $timeFired, eventType: $eventType, data: $data)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,context,origin,timeFired,eventType,const DeepCollectionEquality().hash(_data));
+
+@override
+String toString() {
+  return 'HassEvent(context: $context, origin: $origin, timeFired: $timeFired, eventType: $eventType, data: $data)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class _$HassEventCopyWith<$Res>
-    implements $HassEventCopyWith<$Res> {
-  factory _$HassEventCopyWith(
-          _HassEvent value, $Res Function(_HassEvent) _then) =
-      __$HassEventCopyWithImpl;
-  @override
-  @useResult
-  $Res call(
-      {Context context,
-      String origin,
-      String timeFired,
-      String eventType,
-      Map<String, dynamic> data});
+abstract mixin class _$HassEventCopyWith<$Res> implements $HassEventCopyWith<$Res> {
+  factory _$HassEventCopyWith(_HassEvent value, $Res Function(_HassEvent) _then) = __$HassEventCopyWithImpl;
+@override @useResult
+$Res call({
+ Context context, String origin, String timeFired, String eventType, Map<String, dynamic> data
+});
 
-  @override
-  $ContextCopyWith<$Res> get context;
+
+@override $ContextCopyWith<$Res> get context;
+
 }
-
 /// @nodoc
-class __$HassEventCopyWithImpl<$Res> implements _$HassEventCopyWith<$Res> {
+class __$HassEventCopyWithImpl<$Res>
+    implements _$HassEventCopyWith<$Res> {
   __$HassEventCopyWithImpl(this._self, this._then);
 
   final _HassEvent _self;
   final $Res Function(_HassEvent) _then;
 
-  /// Create a copy of HassEvent
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? context = null,
-    Object? origin = null,
-    Object? timeFired = null,
-    Object? eventType = null,
-    Object? data = null,
-  }) {
-    return _then(_HassEvent(
-      context: null == context
-          ? _self.context
-          : context // ignore: cast_nullable_to_non_nullable
-              as Context,
-      origin: null == origin
-          ? _self.origin
-          : origin // ignore: cast_nullable_to_non_nullable
-              as String,
-      timeFired: null == timeFired
-          ? _self.timeFired
-          : timeFired // ignore: cast_nullable_to_non_nullable
-              as String,
-      eventType: null == eventType
-          ? _self.eventType
-          : eventType // ignore: cast_nullable_to_non_nullable
-              as String,
-      data: null == data
-          ? _self._data
-          : data // ignore: cast_nullable_to_non_nullable
-              as Map<String, dynamic>,
-    ));
-  }
-
-  /// Create a copy of HassEvent
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $ContextCopyWith<$Res> get context {
-    return $ContextCopyWith<$Res>(_self.context, (value) {
-      return _then(_self.copyWith(context: value));
-    });
-  }
+/// Create a copy of HassEvent
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? context = null,Object? origin = null,Object? timeFired = null,Object? eventType = null,Object? data = null,}) {
+  return _then(_HassEvent(
+context: null == context ? _self.context : context // ignore: cast_nullable_to_non_nullable
+as Context,origin: null == origin ? _self.origin : origin // ignore: cast_nullable_to_non_nullable
+as String,timeFired: null == timeFired ? _self.timeFired : timeFired // ignore: cast_nullable_to_non_nullable
+as String,eventType: null == eventType ? _self.eventType : eventType // ignore: cast_nullable_to_non_nullable
+as String,data: null == data ? _self._data : data // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>,
+  ));
 }
+
+/// Create a copy of HassEvent
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$ContextCopyWith<$Res> get context {
+  
+  return $ContextCopyWith<$Res>(_self.context, (value) {
+    return _then(_self.copyWith(context: value));
+  });
+}
+}
+
 
 /// @nodoc
 mixin _$HassEntity {
-  String get entity_id;
-  String get state;
-  String get last_changed;
-  String get last_updated;
-  HassEntityAttributeBase get attributes;
-  Context get context;
 
-  /// Create a copy of HassEntity
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $HassEntityCopyWith<HassEntity> get copyWith =>
-      _$HassEntityCopyWithImpl<HassEntity>(this as HassEntity, _$identity);
+ String get entity_id; String get state; String get last_changed; String get last_updated; HassEntityAttributeBase get attributes; Context get context;
+/// Create a copy of HassEntity
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$HassEntityCopyWith<HassEntity> get copyWith => _$HassEntityCopyWithImpl<HassEntity>(this as HassEntity, _$identity);
 
   /// Serializes this HassEntity to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is HassEntity &&
-            (identical(other.entity_id, entity_id) ||
-                other.entity_id == entity_id) &&
-            (identical(other.state, state) || other.state == state) &&
-            (identical(other.last_changed, last_changed) ||
-                other.last_changed == last_changed) &&
-            (identical(other.last_updated, last_updated) ||
-                other.last_updated == last_updated) &&
-            (identical(other.attributes, attributes) ||
-                other.attributes == attributes) &&
-            (identical(other.context, context) || other.context == context));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(runtimeType, entity_id, state, last_changed,
-      last_updated, attributes, context);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is HassEntity&&(identical(other.entity_id, entity_id) || other.entity_id == entity_id)&&(identical(other.state, state) || other.state == state)&&(identical(other.last_changed, last_changed) || other.last_changed == last_changed)&&(identical(other.last_updated, last_updated) || other.last_updated == last_updated)&&(identical(other.attributes, attributes) || other.attributes == attributes)&&(identical(other.context, context) || other.context == context));
+}
 
-  @override
-  String toString() {
-    return 'HassEntity(entity_id: $entity_id, state: $state, last_changed: $last_changed, last_updated: $last_updated, attributes: $attributes, context: $context)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,entity_id,state,last_changed,last_updated,attributes,context);
+
+@override
+String toString() {
+  return 'HassEntity(entity_id: $entity_id, state: $state, last_changed: $last_changed, last_updated: $last_updated, attributes: $attributes, context: $context)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $HassEntityCopyWith<$Res> {
-  factory $HassEntityCopyWith(
-          HassEntity value, $Res Function(HassEntity) _then) =
-      _$HassEntityCopyWithImpl;
-  @useResult
-  $Res call(
-      {String entity_id,
-      String state,
-      String last_changed,
-      String last_updated,
-      HassEntityAttributeBase attributes,
-      Context context});
+abstract mixin class $HassEntityCopyWith<$Res>  {
+  factory $HassEntityCopyWith(HassEntity value, $Res Function(HassEntity) _then) = _$HassEntityCopyWithImpl;
+@useResult
+$Res call({
+ String entity_id, String state, String last_changed, String last_updated, HassEntityAttributeBase attributes, Context context
+});
 
-  $HassEntityAttributeBaseCopyWith<$Res> get attributes;
-  $ContextCopyWith<$Res> get context;
+
+$HassEntityAttributeBaseCopyWith<$Res> get attributes;$ContextCopyWith<$Res> get context;
+
 }
-
 /// @nodoc
-class _$HassEntityCopyWithImpl<$Res> implements $HassEntityCopyWith<$Res> {
+class _$HassEntityCopyWithImpl<$Res>
+    implements $HassEntityCopyWith<$Res> {
   _$HassEntityCopyWithImpl(this._self, this._then);
 
   final HassEntity _self;
   final $Res Function(HassEntity) _then;
 
-  /// Create a copy of HassEntity
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? entity_id = null,
-    Object? state = null,
-    Object? last_changed = null,
-    Object? last_updated = null,
-    Object? attributes = null,
-    Object? context = null,
-  }) {
-    return _then(_self.copyWith(
-      entity_id: null == entity_id
-          ? _self.entity_id
-          : entity_id // ignore: cast_nullable_to_non_nullable
-              as String,
-      state: null == state
-          ? _self.state
-          : state // ignore: cast_nullable_to_non_nullable
-              as String,
-      last_changed: null == last_changed
-          ? _self.last_changed
-          : last_changed // ignore: cast_nullable_to_non_nullable
-              as String,
-      last_updated: null == last_updated
-          ? _self.last_updated
-          : last_updated // ignore: cast_nullable_to_non_nullable
-              as String,
-      attributes: null == attributes
-          ? _self.attributes
-          : attributes // ignore: cast_nullable_to_non_nullable
-              as HassEntityAttributeBase,
-      context: null == context
-          ? _self.context
-          : context // ignore: cast_nullable_to_non_nullable
-              as Context,
-    ));
-  }
-
-  /// Create a copy of HassEntity
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $HassEntityAttributeBaseCopyWith<$Res> get attributes {
-    return $HassEntityAttributeBaseCopyWith<$Res>(_self.attributes, (value) {
-      return _then(_self.copyWith(attributes: value));
-    });
-  }
-
-  /// Create a copy of HassEntity
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $ContextCopyWith<$Res> get context {
-    return $ContextCopyWith<$Res>(_self.context, (value) {
-      return _then(_self.copyWith(context: value));
-    });
-  }
+/// Create a copy of HassEntity
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? entity_id = null,Object? state = null,Object? last_changed = null,Object? last_updated = null,Object? attributes = null,Object? context = null,}) {
+  return _then(_self.copyWith(
+entity_id: null == entity_id ? _self.entity_id : entity_id // ignore: cast_nullable_to_non_nullable
+as String,state: null == state ? _self.state : state // ignore: cast_nullable_to_non_nullable
+as String,last_changed: null == last_changed ? _self.last_changed : last_changed // ignore: cast_nullable_to_non_nullable
+as String,last_updated: null == last_updated ? _self.last_updated : last_updated // ignore: cast_nullable_to_non_nullable
+as String,attributes: null == attributes ? _self.attributes : attributes // ignore: cast_nullable_to_non_nullable
+as HassEntityAttributeBase,context: null == context ? _self.context : context // ignore: cast_nullable_to_non_nullable
+as Context,
+  ));
 }
+/// Create a copy of HassEntity
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$HassEntityAttributeBaseCopyWith<$Res> get attributes {
+  
+  return $HassEntityAttributeBaseCopyWith<$Res>(_self.attributes, (value) {
+    return _then(_self.copyWith(attributes: value));
+  });
+}/// Create a copy of HassEntity
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$ContextCopyWith<$Res> get context {
+  
+  return $ContextCopyWith<$Res>(_self.context, (value) {
+    return _then(_self.copyWith(context: value));
+  });
+}
+}
+
 
 /// Adds pattern-matching-related methods to [HassEntity].
 extension HassEntityPatterns on HassEntity {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_HassEntity value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _HassEntity() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _HassEntity value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _HassEntity() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_HassEntity value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _HassEntity():
-        return $default(_that);
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _HassEntity value)  $default,){
+final _that = this;
+switch (_that) {
+case _HassEntity():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _HassEntity value)?  $default,){
+final _that = this;
+switch (_that) {
+case _HassEntity() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_HassEntity value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _HassEntity() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String entity_id,  String state,  String last_changed,  String last_updated,  HassEntityAttributeBase attributes,  Context context)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _HassEntity() when $default != null:
+return $default(_that.entity_id,_that.state,_that.last_changed,_that.last_updated,_that.attributes,_that.context);case _:
+  return orElse();
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(
-            String entity_id,
-            String state,
-            String last_changed,
-            String last_updated,
-            HassEntityAttributeBase attributes,
-            Context context)?
-        $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _HassEntity() when $default != null:
-        return $default(_that.entity_id, _that.state, _that.last_changed,
-            _that.last_updated, _that.attributes, _that.context);
-      case _:
-        return orElse();
-    }
-  }
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String entity_id,  String state,  String last_changed,  String last_updated,  HassEntityAttributeBase attributes,  Context context)  $default,) {final _that = this;
+switch (_that) {
+case _HassEntity():
+return $default(_that.entity_id,_that.state,_that.last_changed,_that.last_updated,_that.attributes,_that.context);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(
-            String entity_id,
-            String state,
-            String last_changed,
-            String last_updated,
-            HassEntityAttributeBase attributes,
-            Context context)
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _HassEntity():
-        return $default(_that.entity_id, _that.state, _that.last_changed,
-            _that.last_updated, _that.attributes, _that.context);
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String entity_id,  String state,  String last_changed,  String last_updated,  HassEntityAttributeBase attributes,  Context context)?  $default,) {final _that = this;
+switch (_that) {
+case _HassEntity() when $default != null:
+return $default(_that.entity_id,_that.state,_that.last_changed,_that.last_updated,_that.attributes,_that.context);case _:
+  return null;
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(
-            String entity_id,
-            String state,
-            String last_changed,
-            String last_updated,
-            HassEntityAttributeBase attributes,
-            Context context)?
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _HassEntity() when $default != null:
-        return $default(_that.entity_id, _that.state, _that.last_changed,
-            _that.last_updated, _that.attributes, _that.context);
-      case _:
-        return null;
-    }
-  }
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _HassEntity implements HassEntity {
-  const _HassEntity(
-      {required this.entity_id,
-      required this.state,
-      required this.last_changed,
-      required this.last_updated,
-      required this.attributes,
-      required this.context});
-  factory _HassEntity.fromJson(Map<String, dynamic> json) =>
-      _$HassEntityFromJson(json);
+  const _HassEntity({required this.entity_id, required this.state, required this.last_changed, required this.last_updated, required this.attributes, required this.context});
+  factory _HassEntity.fromJson(Map<String, dynamic> json) => _$HassEntityFromJson(json);
 
-  @override
-  final String entity_id;
-  @override
-  final String state;
-  @override
-  final String last_changed;
-  @override
-  final String last_updated;
-  @override
-  final HassEntityAttributeBase attributes;
-  @override
-  final Context context;
+@override final  String entity_id;
+@override final  String state;
+@override final  String last_changed;
+@override final  String last_updated;
+@override final  HassEntityAttributeBase attributes;
+@override final  Context context;
 
-  /// Create a copy of HassEntity
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$HassEntityCopyWith<_HassEntity> get copyWith =>
-      __$HassEntityCopyWithImpl<_HassEntity>(this, _$identity);
+/// Create a copy of HassEntity
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$HassEntityCopyWith<_HassEntity> get copyWith => __$HassEntityCopyWithImpl<_HassEntity>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$HassEntityToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$HassEntityToJson(this, );
+}
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _HassEntity &&
-            (identical(other.entity_id, entity_id) ||
-                other.entity_id == entity_id) &&
-            (identical(other.state, state) || other.state == state) &&
-            (identical(other.last_changed, last_changed) ||
-                other.last_changed == last_changed) &&
-            (identical(other.last_updated, last_updated) ||
-                other.last_updated == last_updated) &&
-            (identical(other.attributes, attributes) ||
-                other.attributes == attributes) &&
-            (identical(other.context, context) || other.context == context));
-  }
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _HassEntity&&(identical(other.entity_id, entity_id) || other.entity_id == entity_id)&&(identical(other.state, state) || other.state == state)&&(identical(other.last_changed, last_changed) || other.last_changed == last_changed)&&(identical(other.last_updated, last_updated) || other.last_updated == last_updated)&&(identical(other.attributes, attributes) || other.attributes == attributes)&&(identical(other.context, context) || other.context == context));
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(runtimeType, entity_id, state, last_changed,
-      last_updated, attributes, context);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,entity_id,state,last_changed,last_updated,attributes,context);
 
-  @override
-  String toString() {
-    return 'HassEntity(entity_id: $entity_id, state: $state, last_changed: $last_changed, last_updated: $last_updated, attributes: $attributes, context: $context)';
-  }
+@override
+String toString() {
+  return 'HassEntity(entity_id: $entity_id, state: $state, last_changed: $last_changed, last_updated: $last_updated, attributes: $attributes, context: $context)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class _$HassEntityCopyWith<$Res>
-    implements $HassEntityCopyWith<$Res> {
-  factory _$HassEntityCopyWith(
-          _HassEntity value, $Res Function(_HassEntity) _then) =
-      __$HassEntityCopyWithImpl;
-  @override
-  @useResult
-  $Res call(
-      {String entity_id,
-      String state,
-      String last_changed,
-      String last_updated,
-      HassEntityAttributeBase attributes,
-      Context context});
+abstract mixin class _$HassEntityCopyWith<$Res> implements $HassEntityCopyWith<$Res> {
+  factory _$HassEntityCopyWith(_HassEntity value, $Res Function(_HassEntity) _then) = __$HassEntityCopyWithImpl;
+@override @useResult
+$Res call({
+ String entity_id, String state, String last_changed, String last_updated, HassEntityAttributeBase attributes, Context context
+});
 
-  @override
-  $HassEntityAttributeBaseCopyWith<$Res> get attributes;
-  @override
-  $ContextCopyWith<$Res> get context;
+
+@override $HassEntityAttributeBaseCopyWith<$Res> get attributes;@override $ContextCopyWith<$Res> get context;
+
 }
-
 /// @nodoc
-class __$HassEntityCopyWithImpl<$Res> implements _$HassEntityCopyWith<$Res> {
+class __$HassEntityCopyWithImpl<$Res>
+    implements _$HassEntityCopyWith<$Res> {
   __$HassEntityCopyWithImpl(this._self, this._then);
 
   final _HassEntity _self;
   final $Res Function(_HassEntity) _then;
 
-  /// Create a copy of HassEntity
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? entity_id = null,
-    Object? state = null,
-    Object? last_changed = null,
-    Object? last_updated = null,
-    Object? attributes = null,
-    Object? context = null,
-  }) {
-    return _then(_HassEntity(
-      entity_id: null == entity_id
-          ? _self.entity_id
-          : entity_id // ignore: cast_nullable_to_non_nullable
-              as String,
-      state: null == state
-          ? _self.state
-          : state // ignore: cast_nullable_to_non_nullable
-              as String,
-      last_changed: null == last_changed
-          ? _self.last_changed
-          : last_changed // ignore: cast_nullable_to_non_nullable
-              as String,
-      last_updated: null == last_updated
-          ? _self.last_updated
-          : last_updated // ignore: cast_nullable_to_non_nullable
-              as String,
-      attributes: null == attributes
-          ? _self.attributes
-          : attributes // ignore: cast_nullable_to_non_nullable
-              as HassEntityAttributeBase,
-      context: null == context
-          ? _self.context
-          : context // ignore: cast_nullable_to_non_nullable
-              as Context,
-    ));
-  }
-
-  /// Create a copy of HassEntity
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $HassEntityAttributeBaseCopyWith<$Res> get attributes {
-    return $HassEntityAttributeBaseCopyWith<$Res>(_self.attributes, (value) {
-      return _then(_self.copyWith(attributes: value));
-    });
-  }
-
-  /// Create a copy of HassEntity
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $ContextCopyWith<$Res> get context {
-    return $ContextCopyWith<$Res>(_self.context, (value) {
-      return _then(_self.copyWith(context: value));
-    });
-  }
+/// Create a copy of HassEntity
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? entity_id = null,Object? state = null,Object? last_changed = null,Object? last_updated = null,Object? attributes = null,Object? context = null,}) {
+  return _then(_HassEntity(
+entity_id: null == entity_id ? _self.entity_id : entity_id // ignore: cast_nullable_to_non_nullable
+as String,state: null == state ? _self.state : state // ignore: cast_nullable_to_non_nullable
+as String,last_changed: null == last_changed ? _self.last_changed : last_changed // ignore: cast_nullable_to_non_nullable
+as String,last_updated: null == last_updated ? _self.last_updated : last_updated // ignore: cast_nullable_to_non_nullable
+as String,attributes: null == attributes ? _self.attributes : attributes // ignore: cast_nullable_to_non_nullable
+as HassEntityAttributeBase,context: null == context ? _self.context : context // ignore: cast_nullable_to_non_nullable
+as Context,
+  ));
 }
+
+/// Create a copy of HassEntity
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$HassEntityAttributeBaseCopyWith<$Res> get attributes {
+  
+  return $HassEntityAttributeBaseCopyWith<$Res>(_self.attributes, (value) {
+    return _then(_self.copyWith(attributes: value));
+  });
+}/// Create a copy of HassEntity
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$ContextCopyWith<$Res> get context {
+  
+  return $ContextCopyWith<$Res>(_self.context, (value) {
+    return _then(_self.copyWith(context: value));
+  });
+}
+}
+
 
 /// @nodoc
 mixin _$HassEntityAttributeBase {
-  String? get friendly_name;
-  String? get unit_of_measurement;
-  String? get icon;
-  String? get entity_picture;
-  num? get supported_features;
-  bool? get hidden;
-  bool? get assumed_state;
-  String? get device_class;
-  String? get state_class;
-  bool? get restored;
 
-  /// Create a copy of HassEntityAttributeBase
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $HassEntityAttributeBaseCopyWith<HassEntityAttributeBase> get copyWith =>
-      _$HassEntityAttributeBaseCopyWithImpl<HassEntityAttributeBase>(
-          this as HassEntityAttributeBase, _$identity);
+ String? get friendly_name; String? get unit_of_measurement; String? get icon; String? get entity_picture; num? get supported_features; bool? get hidden; bool? get assumed_state; String? get device_class; String? get state_class; bool? get restored;
+/// Create a copy of HassEntityAttributeBase
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$HassEntityAttributeBaseCopyWith<HassEntityAttributeBase> get copyWith => _$HassEntityAttributeBaseCopyWithImpl<HassEntityAttributeBase>(this as HassEntityAttributeBase, _$identity);
 
   /// Serializes this HassEntityAttributeBase to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is HassEntityAttributeBase &&
-            (identical(other.friendly_name, friendly_name) ||
-                other.friendly_name == friendly_name) &&
-            (identical(other.unit_of_measurement, unit_of_measurement) ||
-                other.unit_of_measurement == unit_of_measurement) &&
-            (identical(other.icon, icon) || other.icon == icon) &&
-            (identical(other.entity_picture, entity_picture) ||
-                other.entity_picture == entity_picture) &&
-            (identical(other.supported_features, supported_features) ||
-                other.supported_features == supported_features) &&
-            (identical(other.hidden, hidden) || other.hidden == hidden) &&
-            (identical(other.assumed_state, assumed_state) ||
-                other.assumed_state == assumed_state) &&
-            (identical(other.device_class, device_class) ||
-                other.device_class == device_class) &&
-            (identical(other.state_class, state_class) ||
-                other.state_class == state_class) &&
-            (identical(other.restored, restored) ||
-                other.restored == restored));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      friendly_name,
-      unit_of_measurement,
-      icon,
-      entity_picture,
-      supported_features,
-      hidden,
-      assumed_state,
-      device_class,
-      state_class,
-      restored);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is HassEntityAttributeBase&&(identical(other.friendly_name, friendly_name) || other.friendly_name == friendly_name)&&(identical(other.unit_of_measurement, unit_of_measurement) || other.unit_of_measurement == unit_of_measurement)&&(identical(other.icon, icon) || other.icon == icon)&&(identical(other.entity_picture, entity_picture) || other.entity_picture == entity_picture)&&(identical(other.supported_features, supported_features) || other.supported_features == supported_features)&&(identical(other.hidden, hidden) || other.hidden == hidden)&&(identical(other.assumed_state, assumed_state) || other.assumed_state == assumed_state)&&(identical(other.device_class, device_class) || other.device_class == device_class)&&(identical(other.state_class, state_class) || other.state_class == state_class)&&(identical(other.restored, restored) || other.restored == restored));
+}
 
-  @override
-  String toString() {
-    return 'HassEntityAttributeBase(friendly_name: $friendly_name, unit_of_measurement: $unit_of_measurement, icon: $icon, entity_picture: $entity_picture, supported_features: $supported_features, hidden: $hidden, assumed_state: $assumed_state, device_class: $device_class, state_class: $state_class, restored: $restored)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,friendly_name,unit_of_measurement,icon,entity_picture,supported_features,hidden,assumed_state,device_class,state_class,restored);
+
+@override
+String toString() {
+  return 'HassEntityAttributeBase(friendly_name: $friendly_name, unit_of_measurement: $unit_of_measurement, icon: $icon, entity_picture: $entity_picture, supported_features: $supported_features, hidden: $hidden, assumed_state: $assumed_state, device_class: $device_class, state_class: $state_class, restored: $restored)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $HassEntityAttributeBaseCopyWith<$Res> {
-  factory $HassEntityAttributeBaseCopyWith(HassEntityAttributeBase value,
-          $Res Function(HassEntityAttributeBase) _then) =
-      _$HassEntityAttributeBaseCopyWithImpl;
-  @useResult
-  $Res call(
-      {String? friendly_name,
-      String? unit_of_measurement,
-      String? icon,
-      String? entity_picture,
-      num? supported_features,
-      bool? hidden,
-      bool? assumed_state,
-      String? device_class,
-      String? state_class,
-      bool? restored});
-}
+abstract mixin class $HassEntityAttributeBaseCopyWith<$Res>  {
+  factory $HassEntityAttributeBaseCopyWith(HassEntityAttributeBase value, $Res Function(HassEntityAttributeBase) _then) = _$HassEntityAttributeBaseCopyWithImpl;
+@useResult
+$Res call({
+ String? friendly_name, String? unit_of_measurement, String? icon, String? entity_picture, num? supported_features, bool? hidden, bool? assumed_state, String? device_class, String? state_class, bool? restored
+});
 
+
+
+
+}
 /// @nodoc
 class _$HassEntityAttributeBaseCopyWithImpl<$Res>
     implements $HassEntityAttributeBaseCopyWith<$Res> {
@@ -3541,404 +2645,209 @@ class _$HassEntityAttributeBaseCopyWithImpl<$Res>
   final HassEntityAttributeBase _self;
   final $Res Function(HassEntityAttributeBase) _then;
 
-  /// Create a copy of HassEntityAttributeBase
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? friendly_name = freezed,
-    Object? unit_of_measurement = freezed,
-    Object? icon = freezed,
-    Object? entity_picture = freezed,
-    Object? supported_features = freezed,
-    Object? hidden = freezed,
-    Object? assumed_state = freezed,
-    Object? device_class = freezed,
-    Object? state_class = freezed,
-    Object? restored = freezed,
-  }) {
-    return _then(_self.copyWith(
-      friendly_name: freezed == friendly_name
-          ? _self.friendly_name
-          : friendly_name // ignore: cast_nullable_to_non_nullable
-              as String?,
-      unit_of_measurement: freezed == unit_of_measurement
-          ? _self.unit_of_measurement
-          : unit_of_measurement // ignore: cast_nullable_to_non_nullable
-              as String?,
-      icon: freezed == icon
-          ? _self.icon
-          : icon // ignore: cast_nullable_to_non_nullable
-              as String?,
-      entity_picture: freezed == entity_picture
-          ? _self.entity_picture
-          : entity_picture // ignore: cast_nullable_to_non_nullable
-              as String?,
-      supported_features: freezed == supported_features
-          ? _self.supported_features
-          : supported_features // ignore: cast_nullable_to_non_nullable
-              as num?,
-      hidden: freezed == hidden
-          ? _self.hidden
-          : hidden // ignore: cast_nullable_to_non_nullable
-              as bool?,
-      assumed_state: freezed == assumed_state
-          ? _self.assumed_state
-          : assumed_state // ignore: cast_nullable_to_non_nullable
-              as bool?,
-      device_class: freezed == device_class
-          ? _self.device_class
-          : device_class // ignore: cast_nullable_to_non_nullable
-              as String?,
-      state_class: freezed == state_class
-          ? _self.state_class
-          : state_class // ignore: cast_nullable_to_non_nullable
-              as String?,
-      restored: freezed == restored
-          ? _self.restored
-          : restored // ignore: cast_nullable_to_non_nullable
-              as bool?,
-    ));
-  }
+/// Create a copy of HassEntityAttributeBase
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? friendly_name = freezed,Object? unit_of_measurement = freezed,Object? icon = freezed,Object? entity_picture = freezed,Object? supported_features = freezed,Object? hidden = freezed,Object? assumed_state = freezed,Object? device_class = freezed,Object? state_class = freezed,Object? restored = freezed,}) {
+  return _then(_self.copyWith(
+friendly_name: freezed == friendly_name ? _self.friendly_name : friendly_name // ignore: cast_nullable_to_non_nullable
+as String?,unit_of_measurement: freezed == unit_of_measurement ? _self.unit_of_measurement : unit_of_measurement // ignore: cast_nullable_to_non_nullable
+as String?,icon: freezed == icon ? _self.icon : icon // ignore: cast_nullable_to_non_nullable
+as String?,entity_picture: freezed == entity_picture ? _self.entity_picture : entity_picture // ignore: cast_nullable_to_non_nullable
+as String?,supported_features: freezed == supported_features ? _self.supported_features : supported_features // ignore: cast_nullable_to_non_nullable
+as num?,hidden: freezed == hidden ? _self.hidden : hidden // ignore: cast_nullable_to_non_nullable
+as bool?,assumed_state: freezed == assumed_state ? _self.assumed_state : assumed_state // ignore: cast_nullable_to_non_nullable
+as bool?,device_class: freezed == device_class ? _self.device_class : device_class // ignore: cast_nullable_to_non_nullable
+as String?,state_class: freezed == state_class ? _self.state_class : state_class // ignore: cast_nullable_to_non_nullable
+as String?,restored: freezed == restored ? _self.restored : restored // ignore: cast_nullable_to_non_nullable
+as bool?,
+  ));
 }
+
+}
+
 
 /// Adds pattern-matching-related methods to [HassEntityAttributeBase].
 extension HassEntityAttributeBasePatterns on HassEntityAttributeBase {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_HassEntityAttributeBase value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _HassEntityAttributeBase() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _HassEntityAttributeBase value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _HassEntityAttributeBase() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_HassEntityAttributeBase value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _HassEntityAttributeBase():
-        return $default(_that);
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _HassEntityAttributeBase value)  $default,){
+final _that = this;
+switch (_that) {
+case _HassEntityAttributeBase():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _HassEntityAttributeBase value)?  $default,){
+final _that = this;
+switch (_that) {
+case _HassEntityAttributeBase() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_HassEntityAttributeBase value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _HassEntityAttributeBase() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? friendly_name,  String? unit_of_measurement,  String? icon,  String? entity_picture,  num? supported_features,  bool? hidden,  bool? assumed_state,  String? device_class,  String? state_class,  bool? restored)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _HassEntityAttributeBase() when $default != null:
+return $default(_that.friendly_name,_that.unit_of_measurement,_that.icon,_that.entity_picture,_that.supported_features,_that.hidden,_that.assumed_state,_that.device_class,_that.state_class,_that.restored);case _:
+  return orElse();
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(
-            String? friendly_name,
-            String? unit_of_measurement,
-            String? icon,
-            String? entity_picture,
-            num? supported_features,
-            bool? hidden,
-            bool? assumed_state,
-            String? device_class,
-            String? state_class,
-            bool? restored)?
-        $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _HassEntityAttributeBase() when $default != null:
-        return $default(
-            _that.friendly_name,
-            _that.unit_of_measurement,
-            _that.icon,
-            _that.entity_picture,
-            _that.supported_features,
-            _that.hidden,
-            _that.assumed_state,
-            _that.device_class,
-            _that.state_class,
-            _that.restored);
-      case _:
-        return orElse();
-    }
-  }
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? friendly_name,  String? unit_of_measurement,  String? icon,  String? entity_picture,  num? supported_features,  bool? hidden,  bool? assumed_state,  String? device_class,  String? state_class,  bool? restored)  $default,) {final _that = this;
+switch (_that) {
+case _HassEntityAttributeBase():
+return $default(_that.friendly_name,_that.unit_of_measurement,_that.icon,_that.entity_picture,_that.supported_features,_that.hidden,_that.assumed_state,_that.device_class,_that.state_class,_that.restored);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(
-            String? friendly_name,
-            String? unit_of_measurement,
-            String? icon,
-            String? entity_picture,
-            num? supported_features,
-            bool? hidden,
-            bool? assumed_state,
-            String? device_class,
-            String? state_class,
-            bool? restored)
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _HassEntityAttributeBase():
-        return $default(
-            _that.friendly_name,
-            _that.unit_of_measurement,
-            _that.icon,
-            _that.entity_picture,
-            _that.supported_features,
-            _that.hidden,
-            _that.assumed_state,
-            _that.device_class,
-            _that.state_class,
-            _that.restored);
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? friendly_name,  String? unit_of_measurement,  String? icon,  String? entity_picture,  num? supported_features,  bool? hidden,  bool? assumed_state,  String? device_class,  String? state_class,  bool? restored)?  $default,) {final _that = this;
+switch (_that) {
+case _HassEntityAttributeBase() when $default != null:
+return $default(_that.friendly_name,_that.unit_of_measurement,_that.icon,_that.entity_picture,_that.supported_features,_that.hidden,_that.assumed_state,_that.device_class,_that.state_class,_that.restored);case _:
+  return null;
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(
-            String? friendly_name,
-            String? unit_of_measurement,
-            String? icon,
-            String? entity_picture,
-            num? supported_features,
-            bool? hidden,
-            bool? assumed_state,
-            String? device_class,
-            String? state_class,
-            bool? restored)?
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _HassEntityAttributeBase() when $default != null:
-        return $default(
-            _that.friendly_name,
-            _that.unit_of_measurement,
-            _that.icon,
-            _that.entity_picture,
-            _that.supported_features,
-            _that.hidden,
-            _that.assumed_state,
-            _that.device_class,
-            _that.state_class,
-            _that.restored);
-      case _:
-        return null;
-    }
-  }
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _HassEntityAttributeBase implements HassEntityAttributeBase {
-  const _HassEntityAttributeBase(
-      {this.friendly_name,
-      this.unit_of_measurement,
-      this.icon,
-      this.entity_picture,
-      this.supported_features,
-      this.hidden,
-      this.assumed_state,
-      this.device_class,
-      this.state_class,
-      this.restored});
-  factory _HassEntityAttributeBase.fromJson(Map<String, dynamic> json) =>
-      _$HassEntityAttributeBaseFromJson(json);
+  const _HassEntityAttributeBase({this.friendly_name, this.unit_of_measurement, this.icon, this.entity_picture, this.supported_features, this.hidden, this.assumed_state, this.device_class, this.state_class, this.restored});
+  factory _HassEntityAttributeBase.fromJson(Map<String, dynamic> json) => _$HassEntityAttributeBaseFromJson(json);
 
-  @override
-  final String? friendly_name;
-  @override
-  final String? unit_of_measurement;
-  @override
-  final String? icon;
-  @override
-  final String? entity_picture;
-  @override
-  final num? supported_features;
-  @override
-  final bool? hidden;
-  @override
-  final bool? assumed_state;
-  @override
-  final String? device_class;
-  @override
-  final String? state_class;
-  @override
-  final bool? restored;
+@override final  String? friendly_name;
+@override final  String? unit_of_measurement;
+@override final  String? icon;
+@override final  String? entity_picture;
+@override final  num? supported_features;
+@override final  bool? hidden;
+@override final  bool? assumed_state;
+@override final  String? device_class;
+@override final  String? state_class;
+@override final  bool? restored;
 
-  /// Create a copy of HassEntityAttributeBase
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$HassEntityAttributeBaseCopyWith<_HassEntityAttributeBase> get copyWith =>
-      __$HassEntityAttributeBaseCopyWithImpl<_HassEntityAttributeBase>(
-          this, _$identity);
+/// Create a copy of HassEntityAttributeBase
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$HassEntityAttributeBaseCopyWith<_HassEntityAttributeBase> get copyWith => __$HassEntityAttributeBaseCopyWithImpl<_HassEntityAttributeBase>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$HassEntityAttributeBaseToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$HassEntityAttributeBaseToJson(this, );
+}
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _HassEntityAttributeBase &&
-            (identical(other.friendly_name, friendly_name) ||
-                other.friendly_name == friendly_name) &&
-            (identical(other.unit_of_measurement, unit_of_measurement) ||
-                other.unit_of_measurement == unit_of_measurement) &&
-            (identical(other.icon, icon) || other.icon == icon) &&
-            (identical(other.entity_picture, entity_picture) ||
-                other.entity_picture == entity_picture) &&
-            (identical(other.supported_features, supported_features) ||
-                other.supported_features == supported_features) &&
-            (identical(other.hidden, hidden) || other.hidden == hidden) &&
-            (identical(other.assumed_state, assumed_state) ||
-                other.assumed_state == assumed_state) &&
-            (identical(other.device_class, device_class) ||
-                other.device_class == device_class) &&
-            (identical(other.state_class, state_class) ||
-                other.state_class == state_class) &&
-            (identical(other.restored, restored) ||
-                other.restored == restored));
-  }
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _HassEntityAttributeBase&&(identical(other.friendly_name, friendly_name) || other.friendly_name == friendly_name)&&(identical(other.unit_of_measurement, unit_of_measurement) || other.unit_of_measurement == unit_of_measurement)&&(identical(other.icon, icon) || other.icon == icon)&&(identical(other.entity_picture, entity_picture) || other.entity_picture == entity_picture)&&(identical(other.supported_features, supported_features) || other.supported_features == supported_features)&&(identical(other.hidden, hidden) || other.hidden == hidden)&&(identical(other.assumed_state, assumed_state) || other.assumed_state == assumed_state)&&(identical(other.device_class, device_class) || other.device_class == device_class)&&(identical(other.state_class, state_class) || other.state_class == state_class)&&(identical(other.restored, restored) || other.restored == restored));
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      friendly_name,
-      unit_of_measurement,
-      icon,
-      entity_picture,
-      supported_features,
-      hidden,
-      assumed_state,
-      device_class,
-      state_class,
-      restored);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,friendly_name,unit_of_measurement,icon,entity_picture,supported_features,hidden,assumed_state,device_class,state_class,restored);
 
-  @override
-  String toString() {
-    return 'HassEntityAttributeBase(friendly_name: $friendly_name, unit_of_measurement: $unit_of_measurement, icon: $icon, entity_picture: $entity_picture, supported_features: $supported_features, hidden: $hidden, assumed_state: $assumed_state, device_class: $device_class, state_class: $state_class, restored: $restored)';
-  }
+@override
+String toString() {
+  return 'HassEntityAttributeBase(friendly_name: $friendly_name, unit_of_measurement: $unit_of_measurement, icon: $icon, entity_picture: $entity_picture, supported_features: $supported_features, hidden: $hidden, assumed_state: $assumed_state, device_class: $device_class, state_class: $state_class, restored: $restored)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class _$HassEntityAttributeBaseCopyWith<$Res>
-    implements $HassEntityAttributeBaseCopyWith<$Res> {
-  factory _$HassEntityAttributeBaseCopyWith(_HassEntityAttributeBase value,
-          $Res Function(_HassEntityAttributeBase) _then) =
-      __$HassEntityAttributeBaseCopyWithImpl;
-  @override
-  @useResult
-  $Res call(
-      {String? friendly_name,
-      String? unit_of_measurement,
-      String? icon,
-      String? entity_picture,
-      num? supported_features,
-      bool? hidden,
-      bool? assumed_state,
-      String? device_class,
-      String? state_class,
-      bool? restored});
-}
+abstract mixin class _$HassEntityAttributeBaseCopyWith<$Res> implements $HassEntityAttributeBaseCopyWith<$Res> {
+  factory _$HassEntityAttributeBaseCopyWith(_HassEntityAttributeBase value, $Res Function(_HassEntityAttributeBase) _then) = __$HassEntityAttributeBaseCopyWithImpl;
+@override @useResult
+$Res call({
+ String? friendly_name, String? unit_of_measurement, String? icon, String? entity_picture, num? supported_features, bool? hidden, bool? assumed_state, String? device_class, String? state_class, bool? restored
+});
 
+
+
+
+}
 /// @nodoc
 class __$HassEntityAttributeBaseCopyWithImpl<$Res>
     implements _$HassEntityAttributeBaseCopyWith<$Res> {
@@ -3947,65 +2856,25 @@ class __$HassEntityAttributeBaseCopyWithImpl<$Res>
   final _HassEntityAttributeBase _self;
   final $Res Function(_HassEntityAttributeBase) _then;
 
-  /// Create a copy of HassEntityAttributeBase
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? friendly_name = freezed,
-    Object? unit_of_measurement = freezed,
-    Object? icon = freezed,
-    Object? entity_picture = freezed,
-    Object? supported_features = freezed,
-    Object? hidden = freezed,
-    Object? assumed_state = freezed,
-    Object? device_class = freezed,
-    Object? state_class = freezed,
-    Object? restored = freezed,
-  }) {
-    return _then(_HassEntityAttributeBase(
-      friendly_name: freezed == friendly_name
-          ? _self.friendly_name
-          : friendly_name // ignore: cast_nullable_to_non_nullable
-              as String?,
-      unit_of_measurement: freezed == unit_of_measurement
-          ? _self.unit_of_measurement
-          : unit_of_measurement // ignore: cast_nullable_to_non_nullable
-              as String?,
-      icon: freezed == icon
-          ? _self.icon
-          : icon // ignore: cast_nullable_to_non_nullable
-              as String?,
-      entity_picture: freezed == entity_picture
-          ? _self.entity_picture
-          : entity_picture // ignore: cast_nullable_to_non_nullable
-              as String?,
-      supported_features: freezed == supported_features
-          ? _self.supported_features
-          : supported_features // ignore: cast_nullable_to_non_nullable
-              as num?,
-      hidden: freezed == hidden
-          ? _self.hidden
-          : hidden // ignore: cast_nullable_to_non_nullable
-              as bool?,
-      assumed_state: freezed == assumed_state
-          ? _self.assumed_state
-          : assumed_state // ignore: cast_nullable_to_non_nullable
-              as bool?,
-      device_class: freezed == device_class
-          ? _self.device_class
-          : device_class // ignore: cast_nullable_to_non_nullable
-              as String?,
-      state_class: freezed == state_class
-          ? _self.state_class
-          : state_class // ignore: cast_nullable_to_non_nullable
-              as String?,
-      restored: freezed == restored
-          ? _self.restored
-          : restored // ignore: cast_nullable_to_non_nullable
-              as bool?,
-    ));
-  }
+/// Create a copy of HassEntityAttributeBase
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? friendly_name = freezed,Object? unit_of_measurement = freezed,Object? icon = freezed,Object? entity_picture = freezed,Object? supported_features = freezed,Object? hidden = freezed,Object? assumed_state = freezed,Object? device_class = freezed,Object? state_class = freezed,Object? restored = freezed,}) {
+  return _then(_HassEntityAttributeBase(
+friendly_name: freezed == friendly_name ? _self.friendly_name : friendly_name // ignore: cast_nullable_to_non_nullable
+as String?,unit_of_measurement: freezed == unit_of_measurement ? _self.unit_of_measurement : unit_of_measurement // ignore: cast_nullable_to_non_nullable
+as String?,icon: freezed == icon ? _self.icon : icon // ignore: cast_nullable_to_non_nullable
+as String?,entity_picture: freezed == entity_picture ? _self.entity_picture : entity_picture // ignore: cast_nullable_to_non_nullable
+as String?,supported_features: freezed == supported_features ? _self.supported_features : supported_features // ignore: cast_nullable_to_non_nullable
+as num?,hidden: freezed == hidden ? _self.hidden : hidden // ignore: cast_nullable_to_non_nullable
+as bool?,assumed_state: freezed == assumed_state ? _self.assumed_state : assumed_state // ignore: cast_nullable_to_non_nullable
+as bool?,device_class: freezed == device_class ? _self.device_class : device_class // ignore: cast_nullable_to_non_nullable
+as String?,state_class: freezed == state_class ? _self.state_class : state_class // ignore: cast_nullable_to_non_nullable
+as String?,restored: freezed == restored ? _self.restored : restored // ignore: cast_nullable_to_non_nullable
+as bool?,
+  ));
+}
+
+
 }
 
 // dart format on

--- a/packages/home_assistant_websocket/lib/src/types/hass_service.dart
+++ b/packages/home_assistant_websocket/lib/src/types/hass_service.dart
@@ -1,4 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+
 part 'hass_service.freezed.dart';
 part 'hass_service.g.dart';
 
@@ -66,7 +67,7 @@ class HassServicesConverter
 sealed class HassService with _$HassService {
   const factory HassService({
     String? name,
-    required String description,
+    String? description,
     Map<String, dynamic>? target,
     required Map<String, Field> fields,
     Response? response,

--- a/packages/home_assistant_websocket/lib/src/types/hass_service.freezed.dart
+++ b/packages/home_assistant_websocket/lib/src/types/hass_service.freezed.dart
@@ -14,47 +14,47 @@ T _$identity<T>(T value) => value;
 
 /// @nodoc
 mixin _$HassDomainServices {
-  Map<String, HassService> get services;
 
-  /// Create a copy of HassDomainServices
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $HassDomainServicesCopyWith<HassDomainServices> get copyWith =>
-      _$HassDomainServicesCopyWithImpl<HassDomainServices>(
-          this as HassDomainServices, _$identity);
+ Map<String, HassService> get services;
+/// Create a copy of HassDomainServices
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$HassDomainServicesCopyWith<HassDomainServices> get copyWith => _$HassDomainServicesCopyWithImpl<HassDomainServices>(this as HassDomainServices, _$identity);
 
   /// Serializes this HassDomainServices to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is HassDomainServices &&
-            const DeepCollectionEquality().equals(other.services, services));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode =>
-      Object.hash(runtimeType, const DeepCollectionEquality().hash(services));
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is HassDomainServices&&const DeepCollectionEquality().equals(other.services, services));
+}
 
-  @override
-  String toString() {
-    return 'HassDomainServices(services: $services)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(services));
+
+@override
+String toString() {
+  return 'HassDomainServices(services: $services)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $HassDomainServicesCopyWith<$Res> {
-  factory $HassDomainServicesCopyWith(
-          HassDomainServices value, $Res Function(HassDomainServices) _then) =
-      _$HassDomainServicesCopyWithImpl;
-  @useResult
-  $Res call({Map<String, HassService> services});
-}
+abstract mixin class $HassDomainServicesCopyWith<$Res>  {
+  factory $HassDomainServicesCopyWith(HassDomainServices value, $Res Function(HassDomainServices) _then) = _$HassDomainServicesCopyWithImpl;
+@useResult
+$Res call({
+ Map<String, HassService> services
+});
 
+
+
+
+}
 /// @nodoc
 class _$HassDomainServicesCopyWithImpl<$Res>
     implements $HassDomainServicesCopyWith<$Res> {
@@ -63,236 +63,197 @@ class _$HassDomainServicesCopyWithImpl<$Res>
   final HassDomainServices _self;
   final $Res Function(HassDomainServices) _then;
 
-  /// Create a copy of HassDomainServices
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? services = null,
-  }) {
-    return _then(_self.copyWith(
-      services: null == services
-          ? _self.services
-          : services // ignore: cast_nullable_to_non_nullable
-              as Map<String, HassService>,
-    ));
-  }
+/// Create a copy of HassDomainServices
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? services = null,}) {
+  return _then(_self.copyWith(
+services: null == services ? _self.services : services // ignore: cast_nullable_to_non_nullable
+as Map<String, HassService>,
+  ));
 }
+
+}
+
 
 /// Adds pattern-matching-related methods to [HassDomainServices].
 extension HassDomainServicesPatterns on HassDomainServices {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_HassDomainServices value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _HassDomainServices() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _HassDomainServices value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _HassDomainServices() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_HassDomainServices value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _HassDomainServices():
-        return $default(_that);
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _HassDomainServices value)  $default,){
+final _that = this;
+switch (_that) {
+case _HassDomainServices():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _HassDomainServices value)?  $default,){
+final _that = this;
+switch (_that) {
+case _HassDomainServices() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_HassDomainServices value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _HassDomainServices() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( Map<String, HassService> services)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _HassDomainServices() when $default != null:
+return $default(_that.services);case _:
+  return orElse();
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(Map<String, HassService> services)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _HassDomainServices() when $default != null:
-        return $default(_that.services);
-      case _:
-        return orElse();
-    }
-  }
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( Map<String, HassService> services)  $default,) {final _that = this;
+switch (_that) {
+case _HassDomainServices():
+return $default(_that.services);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(Map<String, HassService> services) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _HassDomainServices():
-        return $default(_that.services);
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( Map<String, HassService> services)?  $default,) {final _that = this;
+switch (_that) {
+case _HassDomainServices() when $default != null:
+return $default(_that.services);case _:
+  return null;
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(Map<String, HassService> services)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _HassDomainServices() when $default != null:
-        return $default(_that.services);
-      case _:
-        return null;
-    }
-  }
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _HassDomainServices implements HassDomainServices {
-  _HassDomainServices(final Map<String, HassService> services)
-      : _services = services;
-  factory _HassDomainServices.fromJson(Map<String, dynamic> json) =>
-      _$HassDomainServicesFromJson(json);
+   _HassDomainServices(final  Map<String, HassService> services): _services = services;
+  factory _HassDomainServices.fromJson(Map<String, dynamic> json) => _$HassDomainServicesFromJson(json);
 
-  final Map<String, HassService> _services;
-  @override
-  Map<String, HassService> get services {
-    if (_services is EqualUnmodifiableMapView) return _services;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableMapView(_services);
-  }
+ final  Map<String, HassService> _services;
+@override Map<String, HassService> get services {
+  if (_services is EqualUnmodifiableMapView) return _services;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(_services);
+}
 
-  /// Create a copy of HassDomainServices
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$HassDomainServicesCopyWith<_HassDomainServices> get copyWith =>
-      __$HassDomainServicesCopyWithImpl<_HassDomainServices>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$HassDomainServicesToJson(
-      this,
-    );
-  }
+/// Create a copy of HassDomainServices
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$HassDomainServicesCopyWith<_HassDomainServices> get copyWith => __$HassDomainServicesCopyWithImpl<_HassDomainServices>(this, _$identity);
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _HassDomainServices &&
-            const DeepCollectionEquality().equals(other._services, _services));
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$HassDomainServicesToJson(this, );
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode =>
-      Object.hash(runtimeType, const DeepCollectionEquality().hash(_services));
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _HassDomainServices&&const DeepCollectionEquality().equals(other._services, _services));
+}
 
-  @override
-  String toString() {
-    return 'HassDomainServices(services: $services)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_services));
+
+@override
+String toString() {
+  return 'HassDomainServices(services: $services)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class _$HassDomainServicesCopyWith<$Res>
-    implements $HassDomainServicesCopyWith<$Res> {
-  factory _$HassDomainServicesCopyWith(
-          _HassDomainServices value, $Res Function(_HassDomainServices) _then) =
-      __$HassDomainServicesCopyWithImpl;
-  @override
-  @useResult
-  $Res call({Map<String, HassService> services});
-}
+abstract mixin class _$HassDomainServicesCopyWith<$Res> implements $HassDomainServicesCopyWith<$Res> {
+  factory _$HassDomainServicesCopyWith(_HassDomainServices value, $Res Function(_HassDomainServices) _then) = __$HassDomainServicesCopyWithImpl;
+@override @useResult
+$Res call({
+ Map<String, HassService> services
+});
 
+
+
+
+}
 /// @nodoc
 class __$HassDomainServicesCopyWithImpl<$Res>
     implements _$HassDomainServicesCopyWith<$Res> {
@@ -301,302 +262,261 @@ class __$HassDomainServicesCopyWithImpl<$Res>
   final _HassDomainServices _self;
   final $Res Function(_HassDomainServices) _then;
 
-  /// Create a copy of HassDomainServices
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? services = null,
-  }) {
-    return _then(_HassDomainServices(
-      null == services
-          ? _self._services
-          : services // ignore: cast_nullable_to_non_nullable
-              as Map<String, HassService>,
-    ));
-  }
+/// Create a copy of HassDomainServices
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? services = null,}) {
+  return _then(_HassDomainServices(
+null == services ? _self._services : services // ignore: cast_nullable_to_non_nullable
+as Map<String, HassService>,
+  ));
 }
+
+
+}
+
 
 /// @nodoc
 mixin _$HassServices {
-  Map<String, HassDomainServices> get domains;
 
-  /// Create a copy of HassServices
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $HassServicesCopyWith<HassServices> get copyWith =>
-      _$HassServicesCopyWithImpl<HassServices>(
-          this as HassServices, _$identity);
+ Map<String, HassDomainServices> get domains;
+/// Create a copy of HassServices
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$HassServicesCopyWith<HassServices> get copyWith => _$HassServicesCopyWithImpl<HassServices>(this as HassServices, _$identity);
 
   /// Serializes this HassServices to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is HassServices &&
-            const DeepCollectionEquality().equals(other.domains, domains));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode =>
-      Object.hash(runtimeType, const DeepCollectionEquality().hash(domains));
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is HassServices&&const DeepCollectionEquality().equals(other.domains, domains));
+}
 
-  @override
-  String toString() {
-    return 'HassServices(domains: $domains)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(domains));
+
+@override
+String toString() {
+  return 'HassServices(domains: $domains)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $HassServicesCopyWith<$Res> {
-  factory $HassServicesCopyWith(
-          HassServices value, $Res Function(HassServices) _then) =
-      _$HassServicesCopyWithImpl;
-  @useResult
-  $Res call({Map<String, HassDomainServices> domains});
-}
+abstract mixin class $HassServicesCopyWith<$Res>  {
+  factory $HassServicesCopyWith(HassServices value, $Res Function(HassServices) _then) = _$HassServicesCopyWithImpl;
+@useResult
+$Res call({
+ Map<String, HassDomainServices> domains
+});
 
+
+
+
+}
 /// @nodoc
-class _$HassServicesCopyWithImpl<$Res> implements $HassServicesCopyWith<$Res> {
+class _$HassServicesCopyWithImpl<$Res>
+    implements $HassServicesCopyWith<$Res> {
   _$HassServicesCopyWithImpl(this._self, this._then);
 
   final HassServices _self;
   final $Res Function(HassServices) _then;
 
-  /// Create a copy of HassServices
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? domains = null,
-  }) {
-    return _then(_self.copyWith(
-      domains: null == domains
-          ? _self.domains
-          : domains // ignore: cast_nullable_to_non_nullable
-              as Map<String, HassDomainServices>,
-    ));
-  }
+/// Create a copy of HassServices
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? domains = null,}) {
+  return _then(_self.copyWith(
+domains: null == domains ? _self.domains : domains // ignore: cast_nullable_to_non_nullable
+as Map<String, HassDomainServices>,
+  ));
 }
+
+}
+
 
 /// Adds pattern-matching-related methods to [HassServices].
 extension HassServicesPatterns on HassServices {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_HassServices value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _HassServices() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _HassServices value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _HassServices() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_HassServices value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _HassServices():
-        return $default(_that);
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _HassServices value)  $default,){
+final _that = this;
+switch (_that) {
+case _HassServices():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _HassServices value)?  $default,){
+final _that = this;
+switch (_that) {
+case _HassServices() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_HassServices value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _HassServices() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( Map<String, HassDomainServices> domains)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _HassServices() when $default != null:
+return $default(_that.domains);case _:
+  return orElse();
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(Map<String, HassDomainServices> domains)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _HassServices() when $default != null:
-        return $default(_that.domains);
-      case _:
-        return orElse();
-    }
-  }
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( Map<String, HassDomainServices> domains)  $default,) {final _that = this;
+switch (_that) {
+case _HassServices():
+return $default(_that.domains);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(Map<String, HassDomainServices> domains) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _HassServices():
-        return $default(_that.domains);
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( Map<String, HassDomainServices> domains)?  $default,) {final _that = this;
+switch (_that) {
+case _HassServices() when $default != null:
+return $default(_that.domains);case _:
+  return null;
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(Map<String, HassDomainServices> domains)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _HassServices() when $default != null:
-        return $default(_that.domains);
-      case _:
-        return null;
-    }
-  }
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _HassServices implements HassServices {
-  _HassServices(final Map<String, HassDomainServices> domains)
-      : _domains = domains;
-  factory _HassServices.fromJson(Map<String, dynamic> json) =>
-      _$HassServicesFromJson(json);
+   _HassServices(final  Map<String, HassDomainServices> domains): _domains = domains;
+  factory _HassServices.fromJson(Map<String, dynamic> json) => _$HassServicesFromJson(json);
 
-  final Map<String, HassDomainServices> _domains;
-  @override
-  Map<String, HassDomainServices> get domains {
-    if (_domains is EqualUnmodifiableMapView) return _domains;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableMapView(_domains);
-  }
+ final  Map<String, HassDomainServices> _domains;
+@override Map<String, HassDomainServices> get domains {
+  if (_domains is EqualUnmodifiableMapView) return _domains;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(_domains);
+}
 
-  /// Create a copy of HassServices
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$HassServicesCopyWith<_HassServices> get copyWith =>
-      __$HassServicesCopyWithImpl<_HassServices>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$HassServicesToJson(
-      this,
-    );
-  }
+/// Create a copy of HassServices
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$HassServicesCopyWith<_HassServices> get copyWith => __$HassServicesCopyWithImpl<_HassServices>(this, _$identity);
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _HassServices &&
-            const DeepCollectionEquality().equals(other._domains, _domains));
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$HassServicesToJson(this, );
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode =>
-      Object.hash(runtimeType, const DeepCollectionEquality().hash(_domains));
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _HassServices&&const DeepCollectionEquality().equals(other._domains, _domains));
+}
 
-  @override
-  String toString() {
-    return 'HassServices(domains: $domains)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_domains));
+
+@override
+String toString() {
+  return 'HassServices(domains: $domains)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class _$HassServicesCopyWith<$Res>
-    implements $HassServicesCopyWith<$Res> {
-  factory _$HassServicesCopyWith(
-          _HassServices value, $Res Function(_HassServices) _then) =
-      __$HassServicesCopyWithImpl;
-  @override
-  @useResult
-  $Res call({Map<String, HassDomainServices> domains});
-}
+abstract mixin class _$HassServicesCopyWith<$Res> implements $HassServicesCopyWith<$Res> {
+  factory _$HassServicesCopyWith(_HassServices value, $Res Function(_HassServices) _then) = __$HassServicesCopyWithImpl;
+@override @useResult
+$Res call({
+ Map<String, HassDomainServices> domains
+});
 
+
+
+
+}
 /// @nodoc
 class __$HassServicesCopyWithImpl<$Res>
     implements _$HassServicesCopyWith<$Res> {
@@ -605,1547 +525,1160 @@ class __$HassServicesCopyWithImpl<$Res>
   final _HassServices _self;
   final $Res Function(_HassServices) _then;
 
-  /// Create a copy of HassServices
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? domains = null,
-  }) {
-    return _then(_HassServices(
-      null == domains
-          ? _self._domains
-          : domains // ignore: cast_nullable_to_non_nullable
-              as Map<String, HassDomainServices>,
-    ));
-  }
+/// Create a copy of HassServices
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? domains = null,}) {
+  return _then(_HassServices(
+null == domains ? _self._domains : domains // ignore: cast_nullable_to_non_nullable
+as Map<String, HassDomainServices>,
+  ));
 }
+
+
+}
+
 
 /// @nodoc
 mixin _$HassService {
-  String? get name;
-  String get description;
-  Map<String, dynamic>? get target;
-  Map<String, Field> get fields;
-  Response? get response;
 
-  /// Create a copy of HassService
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $HassServiceCopyWith<HassService> get copyWith =>
-      _$HassServiceCopyWithImpl<HassService>(this as HassService, _$identity);
+ String? get name; String? get description; Map<String, dynamic>? get target; Map<String, Field> get fields; Response? get response;
+/// Create a copy of HassService
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$HassServiceCopyWith<HassService> get copyWith => _$HassServiceCopyWithImpl<HassService>(this as HassService, _$identity);
 
   /// Serializes this HassService to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is HassService &&
-            (identical(other.name, name) || other.name == name) &&
-            (identical(other.description, description) ||
-                other.description == description) &&
-            const DeepCollectionEquality().equals(other.target, target) &&
-            const DeepCollectionEquality().equals(other.fields, fields) &&
-            (identical(other.response, response) ||
-                other.response == response));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      name,
-      description,
-      const DeepCollectionEquality().hash(target),
-      const DeepCollectionEquality().hash(fields),
-      response);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is HassService&&(identical(other.name, name) || other.name == name)&&(identical(other.description, description) || other.description == description)&&const DeepCollectionEquality().equals(other.target, target)&&const DeepCollectionEquality().equals(other.fields, fields)&&(identical(other.response, response) || other.response == response));
+}
 
-  @override
-  String toString() {
-    return 'HassService(name: $name, description: $description, target: $target, fields: $fields, response: $response)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,name,description,const DeepCollectionEquality().hash(target),const DeepCollectionEquality().hash(fields),response);
+
+@override
+String toString() {
+  return 'HassService(name: $name, description: $description, target: $target, fields: $fields, response: $response)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $HassServiceCopyWith<$Res> {
-  factory $HassServiceCopyWith(
-          HassService value, $Res Function(HassService) _then) =
-      _$HassServiceCopyWithImpl;
-  @useResult
-  $Res call(
-      {String? name,
-      String description,
-      Map<String, dynamic>? target,
-      Map<String, Field> fields,
-      Response? response});
+abstract mixin class $HassServiceCopyWith<$Res>  {
+  factory $HassServiceCopyWith(HassService value, $Res Function(HassService) _then) = _$HassServiceCopyWithImpl;
+@useResult
+$Res call({
+ String? name, String? description, Map<String, dynamic>? target, Map<String, Field> fields, Response? response
+});
 
-  $ResponseCopyWith<$Res>? get response;
+
+$ResponseCopyWith<$Res>? get response;
+
 }
-
 /// @nodoc
-class _$HassServiceCopyWithImpl<$Res> implements $HassServiceCopyWith<$Res> {
+class _$HassServiceCopyWithImpl<$Res>
+    implements $HassServiceCopyWith<$Res> {
   _$HassServiceCopyWithImpl(this._self, this._then);
 
   final HassService _self;
   final $Res Function(HassService) _then;
 
-  /// Create a copy of HassService
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? name = freezed,
-    Object? description = null,
-    Object? target = freezed,
-    Object? fields = null,
-    Object? response = freezed,
-  }) {
-    return _then(_self.copyWith(
-      name: freezed == name
-          ? _self.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String?,
-      description: null == description
-          ? _self.description
-          : description // ignore: cast_nullable_to_non_nullable
-              as String,
-      target: freezed == target
-          ? _self.target
-          : target // ignore: cast_nullable_to_non_nullable
-              as Map<String, dynamic>?,
-      fields: null == fields
-          ? _self.fields
-          : fields // ignore: cast_nullable_to_non_nullable
-              as Map<String, Field>,
-      response: freezed == response
-          ? _self.response
-          : response // ignore: cast_nullable_to_non_nullable
-              as Response?,
-    ));
-  }
-
-  /// Create a copy of HassService
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $ResponseCopyWith<$Res>? get response {
-    if (_self.response == null) {
-      return null;
-    }
-
-    return $ResponseCopyWith<$Res>(_self.response!, (value) {
-      return _then(_self.copyWith(response: value));
-    });
-  }
+/// Create a copy of HassService
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? name = freezed,Object? description = freezed,Object? target = freezed,Object? fields = null,Object? response = freezed,}) {
+  return _then(_self.copyWith(
+name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String?,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String?,target: freezed == target ? _self.target : target // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,fields: null == fields ? _self.fields : fields // ignore: cast_nullable_to_non_nullable
+as Map<String, Field>,response: freezed == response ? _self.response : response // ignore: cast_nullable_to_non_nullable
+as Response?,
+  ));
 }
+/// Create a copy of HassService
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$ResponseCopyWith<$Res>? get response {
+    if (_self.response == null) {
+    return null;
+  }
+
+  return $ResponseCopyWith<$Res>(_self.response!, (value) {
+    return _then(_self.copyWith(response: value));
+  });
+}
+}
+
 
 /// Adds pattern-matching-related methods to [HassService].
 extension HassServicePatterns on HassService {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_HassService value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _HassService() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _HassService value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _HassService() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_HassService value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _HassService():
-        return $default(_that);
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _HassService value)  $default,){
+final _that = this;
+switch (_that) {
+case _HassService():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _HassService value)?  $default,){
+final _that = this;
+switch (_that) {
+case _HassService() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_HassService value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _HassService() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? name,  String? description,  Map<String, dynamic>? target,  Map<String, Field> fields,  Response? response)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _HassService() when $default != null:
+return $default(_that.name,_that.description,_that.target,_that.fields,_that.response);case _:
+  return orElse();
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(
-            String? name,
-            String description,
-            Map<String, dynamic>? target,
-            Map<String, Field> fields,
-            Response? response)?
-        $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _HassService() when $default != null:
-        return $default(_that.name, _that.description, _that.target,
-            _that.fields, _that.response);
-      case _:
-        return orElse();
-    }
-  }
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? name,  String? description,  Map<String, dynamic>? target,  Map<String, Field> fields,  Response? response)  $default,) {final _that = this;
+switch (_that) {
+case _HassService():
+return $default(_that.name,_that.description,_that.target,_that.fields,_that.response);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(
-            String? name,
-            String description,
-            Map<String, dynamic>? target,
-            Map<String, Field> fields,
-            Response? response)
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _HassService():
-        return $default(_that.name, _that.description, _that.target,
-            _that.fields, _that.response);
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? name,  String? description,  Map<String, dynamic>? target,  Map<String, Field> fields,  Response? response)?  $default,) {final _that = this;
+switch (_that) {
+case _HassService() when $default != null:
+return $default(_that.name,_that.description,_that.target,_that.fields,_that.response);case _:
+  return null;
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(
-            String? name,
-            String description,
-            Map<String, dynamic>? target,
-            Map<String, Field> fields,
-            Response? response)?
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _HassService() when $default != null:
-        return $default(_that.name, _that.description, _that.target,
-            _that.fields, _that.response);
-      case _:
-        return null;
-    }
-  }
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _HassService implements HassService {
-  const _HassService(
-      {this.name,
-      required this.description,
-      final Map<String, dynamic>? target,
-      required final Map<String, Field> fields,
-      this.response})
-      : _target = target,
-        _fields = fields;
-  factory _HassService.fromJson(Map<String, dynamic> json) =>
-      _$HassServiceFromJson(json);
+  const _HassService({this.name, this.description, final  Map<String, dynamic>? target, required final  Map<String, Field> fields, this.response}): _target = target,_fields = fields;
+  factory _HassService.fromJson(Map<String, dynamic> json) => _$HassServiceFromJson(json);
 
-  @override
-  final String? name;
-  @override
-  final String description;
-  final Map<String, dynamic>? _target;
-  @override
-  Map<String, dynamic>? get target {
-    final value = _target;
-    if (value == null) return null;
-    if (_target is EqualUnmodifiableMapView) return _target;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableMapView(value);
-  }
+@override final  String? name;
+@override final  String? description;
+ final  Map<String, dynamic>? _target;
+@override Map<String, dynamic>? get target {
+  final value = _target;
+  if (value == null) return null;
+  if (_target is EqualUnmodifiableMapView) return _target;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(value);
+}
 
-  final Map<String, Field> _fields;
-  @override
-  Map<String, Field> get fields {
-    if (_fields is EqualUnmodifiableMapView) return _fields;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableMapView(_fields);
-  }
+ final  Map<String, Field> _fields;
+@override Map<String, Field> get fields {
+  if (_fields is EqualUnmodifiableMapView) return _fields;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(_fields);
+}
 
-  @override
-  final Response? response;
+@override final  Response? response;
 
-  /// Create a copy of HassService
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$HassServiceCopyWith<_HassService> get copyWith =>
-      __$HassServiceCopyWithImpl<_HassService>(this, _$identity);
+/// Create a copy of HassService
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$HassServiceCopyWith<_HassService> get copyWith => __$HassServiceCopyWithImpl<_HassService>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$HassServiceToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$HassServiceToJson(this, );
+}
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _HassService &&
-            (identical(other.name, name) || other.name == name) &&
-            (identical(other.description, description) ||
-                other.description == description) &&
-            const DeepCollectionEquality().equals(other._target, _target) &&
-            const DeepCollectionEquality().equals(other._fields, _fields) &&
-            (identical(other.response, response) ||
-                other.response == response));
-  }
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _HassService&&(identical(other.name, name) || other.name == name)&&(identical(other.description, description) || other.description == description)&&const DeepCollectionEquality().equals(other._target, _target)&&const DeepCollectionEquality().equals(other._fields, _fields)&&(identical(other.response, response) || other.response == response));
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      name,
-      description,
-      const DeepCollectionEquality().hash(_target),
-      const DeepCollectionEquality().hash(_fields),
-      response);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,name,description,const DeepCollectionEquality().hash(_target),const DeepCollectionEquality().hash(_fields),response);
 
-  @override
-  String toString() {
-    return 'HassService(name: $name, description: $description, target: $target, fields: $fields, response: $response)';
-  }
+@override
+String toString() {
+  return 'HassService(name: $name, description: $description, target: $target, fields: $fields, response: $response)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class _$HassServiceCopyWith<$Res>
-    implements $HassServiceCopyWith<$Res> {
-  factory _$HassServiceCopyWith(
-          _HassService value, $Res Function(_HassService) _then) =
-      __$HassServiceCopyWithImpl;
-  @override
-  @useResult
-  $Res call(
-      {String? name,
-      String description,
-      Map<String, dynamic>? target,
-      Map<String, Field> fields,
-      Response? response});
+abstract mixin class _$HassServiceCopyWith<$Res> implements $HassServiceCopyWith<$Res> {
+  factory _$HassServiceCopyWith(_HassService value, $Res Function(_HassService) _then) = __$HassServiceCopyWithImpl;
+@override @useResult
+$Res call({
+ String? name, String? description, Map<String, dynamic>? target, Map<String, Field> fields, Response? response
+});
 
-  @override
-  $ResponseCopyWith<$Res>? get response;
+
+@override $ResponseCopyWith<$Res>? get response;
+
 }
-
 /// @nodoc
-class __$HassServiceCopyWithImpl<$Res> implements _$HassServiceCopyWith<$Res> {
+class __$HassServiceCopyWithImpl<$Res>
+    implements _$HassServiceCopyWith<$Res> {
   __$HassServiceCopyWithImpl(this._self, this._then);
 
   final _HassService _self;
   final $Res Function(_HassService) _then;
 
-  /// Create a copy of HassService
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? name = freezed,
-    Object? description = null,
-    Object? target = freezed,
-    Object? fields = null,
-    Object? response = freezed,
-  }) {
-    return _then(_HassService(
-      name: freezed == name
-          ? _self.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String?,
-      description: null == description
-          ? _self.description
-          : description // ignore: cast_nullable_to_non_nullable
-              as String,
-      target: freezed == target
-          ? _self._target
-          : target // ignore: cast_nullable_to_non_nullable
-              as Map<String, dynamic>?,
-      fields: null == fields
-          ? _self._fields
-          : fields // ignore: cast_nullable_to_non_nullable
-              as Map<String, Field>,
-      response: freezed == response
-          ? _self.response
-          : response // ignore: cast_nullable_to_non_nullable
-              as Response?,
-    ));
-  }
-
-  /// Create a copy of HassService
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $ResponseCopyWith<$Res>? get response {
-    if (_self.response == null) {
-      return null;
-    }
-
-    return $ResponseCopyWith<$Res>(_self.response!, (value) {
-      return _then(_self.copyWith(response: value));
-    });
-  }
+/// Create a copy of HassService
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? name = freezed,Object? description = freezed,Object? target = freezed,Object? fields = null,Object? response = freezed,}) {
+  return _then(_HassService(
+name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String?,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String?,target: freezed == target ? _self._target : target // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,fields: null == fields ? _self._fields : fields // ignore: cast_nullable_to_non_nullable
+as Map<String, Field>,response: freezed == response ? _self.response : response // ignore: cast_nullable_to_non_nullable
+as Response?,
+  ));
 }
+
+/// Create a copy of HassService
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$ResponseCopyWith<$Res>? get response {
+    if (_self.response == null) {
+    return null;
+  }
+
+  return $ResponseCopyWith<$Res>(_self.response!, (value) {
+    return _then(_self.copyWith(response: value));
+  });
+}
+}
+
 
 /// @nodoc
 mixin _$Field {
-  String? get name;
-  String? get description;
-  dynamic get example;
-  Map<String, dynamic>? get selector;
-  FieldFilter? get filter;
 
-  /// Create a copy of Field
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $FieldCopyWith<Field> get copyWith =>
-      _$FieldCopyWithImpl<Field>(this as Field, _$identity);
+ String? get name; String? get description; dynamic get example; Map<String, dynamic>? get selector; FieldFilter? get filter;
+/// Create a copy of Field
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$FieldCopyWith<Field> get copyWith => _$FieldCopyWithImpl<Field>(this as Field, _$identity);
 
   /// Serializes this Field to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is Field &&
-            (identical(other.name, name) || other.name == name) &&
-            (identical(other.description, description) ||
-                other.description == description) &&
-            const DeepCollectionEquality().equals(other.example, example) &&
-            const DeepCollectionEquality().equals(other.selector, selector) &&
-            (identical(other.filter, filter) || other.filter == filter));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      name,
-      description,
-      const DeepCollectionEquality().hash(example),
-      const DeepCollectionEquality().hash(selector),
-      filter);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Field&&(identical(other.name, name) || other.name == name)&&(identical(other.description, description) || other.description == description)&&const DeepCollectionEquality().equals(other.example, example)&&const DeepCollectionEquality().equals(other.selector, selector)&&(identical(other.filter, filter) || other.filter == filter));
+}
 
-  @override
-  String toString() {
-    return 'Field(name: $name, description: $description, example: $example, selector: $selector, filter: $filter)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,name,description,const DeepCollectionEquality().hash(example),const DeepCollectionEquality().hash(selector),filter);
+
+@override
+String toString() {
+  return 'Field(name: $name, description: $description, example: $example, selector: $selector, filter: $filter)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $FieldCopyWith<$Res> {
-  factory $FieldCopyWith(Field value, $Res Function(Field) _then) =
-      _$FieldCopyWithImpl;
-  @useResult
-  $Res call(
-      {String? name,
-      String? description,
-      dynamic example,
-      Map<String, dynamic>? selector,
-      FieldFilter? filter});
+abstract mixin class $FieldCopyWith<$Res>  {
+  factory $FieldCopyWith(Field value, $Res Function(Field) _then) = _$FieldCopyWithImpl;
+@useResult
+$Res call({
+ String? name, String? description, dynamic example, Map<String, dynamic>? selector, FieldFilter? filter
+});
 
-  $FieldFilterCopyWith<$Res>? get filter;
+
+$FieldFilterCopyWith<$Res>? get filter;
+
 }
-
 /// @nodoc
-class _$FieldCopyWithImpl<$Res> implements $FieldCopyWith<$Res> {
+class _$FieldCopyWithImpl<$Res>
+    implements $FieldCopyWith<$Res> {
   _$FieldCopyWithImpl(this._self, this._then);
 
   final Field _self;
   final $Res Function(Field) _then;
 
-  /// Create a copy of Field
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? name = freezed,
-    Object? description = freezed,
-    Object? example = freezed,
-    Object? selector = freezed,
-    Object? filter = freezed,
-  }) {
-    return _then(_self.copyWith(
-      name: freezed == name
-          ? _self.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String?,
-      description: freezed == description
-          ? _self.description
-          : description // ignore: cast_nullable_to_non_nullable
-              as String?,
-      example: freezed == example
-          ? _self.example
-          : example // ignore: cast_nullable_to_non_nullable
-              as dynamic,
-      selector: freezed == selector
-          ? _self.selector
-          : selector // ignore: cast_nullable_to_non_nullable
-              as Map<String, dynamic>?,
-      filter: freezed == filter
-          ? _self.filter
-          : filter // ignore: cast_nullable_to_non_nullable
-              as FieldFilter?,
-    ));
-  }
-
-  /// Create a copy of Field
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $FieldFilterCopyWith<$Res>? get filter {
-    if (_self.filter == null) {
-      return null;
-    }
-
-    return $FieldFilterCopyWith<$Res>(_self.filter!, (value) {
-      return _then(_self.copyWith(filter: value));
-    });
-  }
+/// Create a copy of Field
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? name = freezed,Object? description = freezed,Object? example = freezed,Object? selector = freezed,Object? filter = freezed,}) {
+  return _then(_self.copyWith(
+name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String?,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String?,example: freezed == example ? _self.example : example // ignore: cast_nullable_to_non_nullable
+as dynamic,selector: freezed == selector ? _self.selector : selector // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,filter: freezed == filter ? _self.filter : filter // ignore: cast_nullable_to_non_nullable
+as FieldFilter?,
+  ));
 }
+/// Create a copy of Field
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$FieldFilterCopyWith<$Res>? get filter {
+    if (_self.filter == null) {
+    return null;
+  }
+
+  return $FieldFilterCopyWith<$Res>(_self.filter!, (value) {
+    return _then(_self.copyWith(filter: value));
+  });
+}
+}
+
 
 /// Adds pattern-matching-related methods to [Field].
 extension FieldPatterns on Field {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_Field value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _Field() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Field value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Field() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_Field value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _Field():
-        return $default(_that);
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Field value)  $default,){
+final _that = this;
+switch (_that) {
+case _Field():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Field value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Field() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_Field value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _Field() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? name,  String? description,  dynamic example,  Map<String, dynamic>? selector,  FieldFilter? filter)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Field() when $default != null:
+return $default(_that.name,_that.description,_that.example,_that.selector,_that.filter);case _:
+  return orElse();
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(String? name, String? description, dynamic example,
-            Map<String, dynamic>? selector, FieldFilter? filter)?
-        $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _Field() when $default != null:
-        return $default(_that.name, _that.description, _that.example,
-            _that.selector, _that.filter);
-      case _:
-        return orElse();
-    }
-  }
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? name,  String? description,  dynamic example,  Map<String, dynamic>? selector,  FieldFilter? filter)  $default,) {final _that = this;
+switch (_that) {
+case _Field():
+return $default(_that.name,_that.description,_that.example,_that.selector,_that.filter);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(String? name, String? description, dynamic example,
-            Map<String, dynamic>? selector, FieldFilter? filter)
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _Field():
-        return $default(_that.name, _that.description, _that.example,
-            _that.selector, _that.filter);
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? name,  String? description,  dynamic example,  Map<String, dynamic>? selector,  FieldFilter? filter)?  $default,) {final _that = this;
+switch (_that) {
+case _Field() when $default != null:
+return $default(_that.name,_that.description,_that.example,_that.selector,_that.filter);case _:
+  return null;
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(String? name, String? description, dynamic example,
-            Map<String, dynamic>? selector, FieldFilter? filter)?
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _Field() when $default != null:
-        return $default(_that.name, _that.description, _that.example,
-            _that.selector, _that.filter);
-      case _:
-        return null;
-    }
-  }
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _Field implements Field {
-  const _Field(
-      {this.name = '',
-      this.description = '',
-      this.example,
-      final Map<String, dynamic>? selector,
-      this.filter})
-      : _selector = selector;
+  const _Field({this.name = '', this.description = '', this.example, final  Map<String, dynamic>? selector, this.filter}): _selector = selector;
   factory _Field.fromJson(Map<String, dynamic> json) => _$FieldFromJson(json);
 
-  @override
-  @JsonKey()
-  final String? name;
-  @override
-  @JsonKey()
-  final String? description;
-  @override
-  final dynamic example;
-  final Map<String, dynamic>? _selector;
-  @override
-  Map<String, dynamic>? get selector {
-    final value = _selector;
-    if (value == null) return null;
-    if (_selector is EqualUnmodifiableMapView) return _selector;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableMapView(value);
-  }
+@override@JsonKey() final  String? name;
+@override@JsonKey() final  String? description;
+@override final  dynamic example;
+ final  Map<String, dynamic>? _selector;
+@override Map<String, dynamic>? get selector {
+  final value = _selector;
+  if (value == null) return null;
+  if (_selector is EqualUnmodifiableMapView) return _selector;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(value);
+}
 
-  @override
-  final FieldFilter? filter;
+@override final  FieldFilter? filter;
 
-  /// Create a copy of Field
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$FieldCopyWith<_Field> get copyWith =>
-      __$FieldCopyWithImpl<_Field>(this, _$identity);
+/// Create a copy of Field
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$FieldCopyWith<_Field> get copyWith => __$FieldCopyWithImpl<_Field>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$FieldToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$FieldToJson(this, );
+}
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _Field &&
-            (identical(other.name, name) || other.name == name) &&
-            (identical(other.description, description) ||
-                other.description == description) &&
-            const DeepCollectionEquality().equals(other.example, example) &&
-            const DeepCollectionEquality().equals(other._selector, _selector) &&
-            (identical(other.filter, filter) || other.filter == filter));
-  }
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Field&&(identical(other.name, name) || other.name == name)&&(identical(other.description, description) || other.description == description)&&const DeepCollectionEquality().equals(other.example, example)&&const DeepCollectionEquality().equals(other._selector, _selector)&&(identical(other.filter, filter) || other.filter == filter));
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      name,
-      description,
-      const DeepCollectionEquality().hash(example),
-      const DeepCollectionEquality().hash(_selector),
-      filter);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,name,description,const DeepCollectionEquality().hash(example),const DeepCollectionEquality().hash(_selector),filter);
 
-  @override
-  String toString() {
-    return 'Field(name: $name, description: $description, example: $example, selector: $selector, filter: $filter)';
-  }
+@override
+String toString() {
+  return 'Field(name: $name, description: $description, example: $example, selector: $selector, filter: $filter)';
+}
+
+
 }
 
 /// @nodoc
 abstract mixin class _$FieldCopyWith<$Res> implements $FieldCopyWith<$Res> {
-  factory _$FieldCopyWith(_Field value, $Res Function(_Field) _then) =
-      __$FieldCopyWithImpl;
-  @override
-  @useResult
-  $Res call(
-      {String? name,
-      String? description,
-      dynamic example,
-      Map<String, dynamic>? selector,
-      FieldFilter? filter});
+  factory _$FieldCopyWith(_Field value, $Res Function(_Field) _then) = __$FieldCopyWithImpl;
+@override @useResult
+$Res call({
+ String? name, String? description, dynamic example, Map<String, dynamic>? selector, FieldFilter? filter
+});
 
-  @override
-  $FieldFilterCopyWith<$Res>? get filter;
+
+@override $FieldFilterCopyWith<$Res>? get filter;
+
 }
-
 /// @nodoc
-class __$FieldCopyWithImpl<$Res> implements _$FieldCopyWith<$Res> {
+class __$FieldCopyWithImpl<$Res>
+    implements _$FieldCopyWith<$Res> {
   __$FieldCopyWithImpl(this._self, this._then);
 
   final _Field _self;
   final $Res Function(_Field) _then;
 
-  /// Create a copy of Field
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? name = freezed,
-    Object? description = freezed,
-    Object? example = freezed,
-    Object? selector = freezed,
-    Object? filter = freezed,
-  }) {
-    return _then(_Field(
-      name: freezed == name
-          ? _self.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String?,
-      description: freezed == description
-          ? _self.description
-          : description // ignore: cast_nullable_to_non_nullable
-              as String?,
-      example: freezed == example
-          ? _self.example
-          : example // ignore: cast_nullable_to_non_nullable
-              as dynamic,
-      selector: freezed == selector
-          ? _self._selector
-          : selector // ignore: cast_nullable_to_non_nullable
-              as Map<String, dynamic>?,
-      filter: freezed == filter
-          ? _self.filter
-          : filter // ignore: cast_nullable_to_non_nullable
-              as FieldFilter?,
-    ));
-  }
-
-  /// Create a copy of Field
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $FieldFilterCopyWith<$Res>? get filter {
-    if (_self.filter == null) {
-      return null;
-    }
-
-    return $FieldFilterCopyWith<$Res>(_self.filter!, (value) {
-      return _then(_self.copyWith(filter: value));
-    });
-  }
+/// Create a copy of Field
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? name = freezed,Object? description = freezed,Object? example = freezed,Object? selector = freezed,Object? filter = freezed,}) {
+  return _then(_Field(
+name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String?,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String?,example: freezed == example ? _self.example : example // ignore: cast_nullable_to_non_nullable
+as dynamic,selector: freezed == selector ? _self._selector : selector // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,filter: freezed == filter ? _self.filter : filter // ignore: cast_nullable_to_non_nullable
+as FieldFilter?,
+  ));
 }
+
+/// Create a copy of Field
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$FieldFilterCopyWith<$Res>? get filter {
+    if (_self.filter == null) {
+    return null;
+  }
+
+  return $FieldFilterCopyWith<$Res>(_self.filter!, (value) {
+    return _then(_self.copyWith(filter: value));
+  });
+}
+}
+
 
 /// @nodoc
 mixin _$FieldFilter {
-// ignore: non_constant_identifier_names
-  List<int>? get supported_features;
-  Map<String, dynamic>? get attribute;
 
-  /// Create a copy of FieldFilter
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $FieldFilterCopyWith<FieldFilter> get copyWith =>
-      _$FieldFilterCopyWithImpl<FieldFilter>(this as FieldFilter, _$identity);
+// ignore: non_constant_identifier_names
+ List<int>? get supported_features; Map<String, dynamic>? get attribute;
+/// Create a copy of FieldFilter
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$FieldFilterCopyWith<FieldFilter> get copyWith => _$FieldFilterCopyWithImpl<FieldFilter>(this as FieldFilter, _$identity);
 
   /// Serializes this FieldFilter to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is FieldFilter &&
-            const DeepCollectionEquality()
-                .equals(other.supported_features, supported_features) &&
-            const DeepCollectionEquality().equals(other.attribute, attribute));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(supported_features),
-      const DeepCollectionEquality().hash(attribute));
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is FieldFilter&&const DeepCollectionEquality().equals(other.supported_features, supported_features)&&const DeepCollectionEquality().equals(other.attribute, attribute));
+}
 
-  @override
-  String toString() {
-    return 'FieldFilter(supported_features: $supported_features, attribute: $attribute)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(supported_features),const DeepCollectionEquality().hash(attribute));
+
+@override
+String toString() {
+  return 'FieldFilter(supported_features: $supported_features, attribute: $attribute)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $FieldFilterCopyWith<$Res> {
-  factory $FieldFilterCopyWith(
-          FieldFilter value, $Res Function(FieldFilter) _then) =
-      _$FieldFilterCopyWithImpl;
-  @useResult
-  $Res call({List<int>? supported_features, Map<String, dynamic>? attribute});
-}
+abstract mixin class $FieldFilterCopyWith<$Res>  {
+  factory $FieldFilterCopyWith(FieldFilter value, $Res Function(FieldFilter) _then) = _$FieldFilterCopyWithImpl;
+@useResult
+$Res call({
+ List<int>? supported_features, Map<String, dynamic>? attribute
+});
 
+
+
+
+}
 /// @nodoc
-class _$FieldFilterCopyWithImpl<$Res> implements $FieldFilterCopyWith<$Res> {
+class _$FieldFilterCopyWithImpl<$Res>
+    implements $FieldFilterCopyWith<$Res> {
   _$FieldFilterCopyWithImpl(this._self, this._then);
 
   final FieldFilter _self;
   final $Res Function(FieldFilter) _then;
 
-  /// Create a copy of FieldFilter
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? supported_features = freezed,
-    Object? attribute = freezed,
-  }) {
-    return _then(_self.copyWith(
-      supported_features: freezed == supported_features
-          ? _self.supported_features
-          : supported_features // ignore: cast_nullable_to_non_nullable
-              as List<int>?,
-      attribute: freezed == attribute
-          ? _self.attribute
-          : attribute // ignore: cast_nullable_to_non_nullable
-              as Map<String, dynamic>?,
-    ));
-  }
+/// Create a copy of FieldFilter
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? supported_features = freezed,Object? attribute = freezed,}) {
+  return _then(_self.copyWith(
+supported_features: freezed == supported_features ? _self.supported_features : supported_features // ignore: cast_nullable_to_non_nullable
+as List<int>?,attribute: freezed == attribute ? _self.attribute : attribute // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,
+  ));
 }
+
+}
+
 
 /// Adds pattern-matching-related methods to [FieldFilter].
 extension FieldFilterPatterns on FieldFilter {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_FieldFilter value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _FieldFilter() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _FieldFilter value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _FieldFilter() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_FieldFilter value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _FieldFilter():
-        return $default(_that);
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _FieldFilter value)  $default,){
+final _that = this;
+switch (_that) {
+case _FieldFilter():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _FieldFilter value)?  $default,){
+final _that = this;
+switch (_that) {
+case _FieldFilter() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_FieldFilter value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _FieldFilter() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( List<int>? supported_features,  Map<String, dynamic>? attribute)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _FieldFilter() when $default != null:
+return $default(_that.supported_features,_that.attribute);case _:
+  return orElse();
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(
-            List<int>? supported_features, Map<String, dynamic>? attribute)?
-        $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _FieldFilter() when $default != null:
-        return $default(_that.supported_features, _that.attribute);
-      case _:
-        return orElse();
-    }
-  }
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( List<int>? supported_features,  Map<String, dynamic>? attribute)  $default,) {final _that = this;
+switch (_that) {
+case _FieldFilter():
+return $default(_that.supported_features,_that.attribute);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(
-            List<int>? supported_features, Map<String, dynamic>? attribute)
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _FieldFilter():
-        return $default(_that.supported_features, _that.attribute);
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( List<int>? supported_features,  Map<String, dynamic>? attribute)?  $default,) {final _that = this;
+switch (_that) {
+case _FieldFilter() when $default != null:
+return $default(_that.supported_features,_that.attribute);case _:
+  return null;
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(
-            List<int>? supported_features, Map<String, dynamic>? attribute)?
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _FieldFilter() when $default != null:
-        return $default(_that.supported_features, _that.attribute);
-      case _:
-        return null;
-    }
-  }
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _FieldFilter implements FieldFilter {
-  _FieldFilter(final List<int>? supported_features,
-      final Map<String, dynamic>? attribute)
-      : _supported_features = supported_features,
-        _attribute = attribute;
-  factory _FieldFilter.fromJson(Map<String, dynamic> json) =>
-      _$FieldFilterFromJson(json);
+   _FieldFilter(final  List<int>? supported_features, final  Map<String, dynamic>? attribute): _supported_features = supported_features,_attribute = attribute;
+  factory _FieldFilter.fromJson(Map<String, dynamic> json) => _$FieldFilterFromJson(json);
 
 // ignore: non_constant_identifier_names
-  final List<int>? _supported_features;
+ final  List<int>? _supported_features;
 // ignore: non_constant_identifier_names
-  @override
-  List<int>? get supported_features {
-    final value = _supported_features;
-    if (value == null) return null;
-    if (_supported_features is EqualUnmodifiableListView)
-      return _supported_features;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(value);
-  }
+@override List<int>? get supported_features {
+  final value = _supported_features;
+  if (value == null) return null;
+  if (_supported_features is EqualUnmodifiableListView) return _supported_features;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
+}
 
-  final Map<String, dynamic>? _attribute;
-  @override
-  Map<String, dynamic>? get attribute {
-    final value = _attribute;
-    if (value == null) return null;
-    if (_attribute is EqualUnmodifiableMapView) return _attribute;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableMapView(value);
-  }
+ final  Map<String, dynamic>? _attribute;
+@override Map<String, dynamic>? get attribute {
+  final value = _attribute;
+  if (value == null) return null;
+  if (_attribute is EqualUnmodifiableMapView) return _attribute;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(value);
+}
 
-  /// Create a copy of FieldFilter
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$FieldFilterCopyWith<_FieldFilter> get copyWith =>
-      __$FieldFilterCopyWithImpl<_FieldFilter>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$FieldFilterToJson(
-      this,
-    );
-  }
+/// Create a copy of FieldFilter
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$FieldFilterCopyWith<_FieldFilter> get copyWith => __$FieldFilterCopyWithImpl<_FieldFilter>(this, _$identity);
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _FieldFilter &&
-            const DeepCollectionEquality()
-                .equals(other._supported_features, _supported_features) &&
-            const DeepCollectionEquality()
-                .equals(other._attribute, _attribute));
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$FieldFilterToJson(this, );
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(_supported_features),
-      const DeepCollectionEquality().hash(_attribute));
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _FieldFilter&&const DeepCollectionEquality().equals(other._supported_features, _supported_features)&&const DeepCollectionEquality().equals(other._attribute, _attribute));
+}
 
-  @override
-  String toString() {
-    return 'FieldFilter(supported_features: $supported_features, attribute: $attribute)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_supported_features),const DeepCollectionEquality().hash(_attribute));
+
+@override
+String toString() {
+  return 'FieldFilter(supported_features: $supported_features, attribute: $attribute)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class _$FieldFilterCopyWith<$Res>
-    implements $FieldFilterCopyWith<$Res> {
-  factory _$FieldFilterCopyWith(
-          _FieldFilter value, $Res Function(_FieldFilter) _then) =
-      __$FieldFilterCopyWithImpl;
-  @override
-  @useResult
-  $Res call({List<int>? supported_features, Map<String, dynamic>? attribute});
-}
+abstract mixin class _$FieldFilterCopyWith<$Res> implements $FieldFilterCopyWith<$Res> {
+  factory _$FieldFilterCopyWith(_FieldFilter value, $Res Function(_FieldFilter) _then) = __$FieldFilterCopyWithImpl;
+@override @useResult
+$Res call({
+ List<int>? supported_features, Map<String, dynamic>? attribute
+});
 
+
+
+
+}
 /// @nodoc
-class __$FieldFilterCopyWithImpl<$Res> implements _$FieldFilterCopyWith<$Res> {
+class __$FieldFilterCopyWithImpl<$Res>
+    implements _$FieldFilterCopyWith<$Res> {
   __$FieldFilterCopyWithImpl(this._self, this._then);
 
   final _FieldFilter _self;
   final $Res Function(_FieldFilter) _then;
 
-  /// Create a copy of FieldFilter
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? supported_features = freezed,
-    Object? attribute = freezed,
-  }) {
-    return _then(_FieldFilter(
-      freezed == supported_features
-          ? _self._supported_features
-          : supported_features // ignore: cast_nullable_to_non_nullable
-              as List<int>?,
-      freezed == attribute
-          ? _self._attribute
-          : attribute // ignore: cast_nullable_to_non_nullable
-              as Map<String, dynamic>?,
-    ));
-  }
+/// Create a copy of FieldFilter
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? supported_features = freezed,Object? attribute = freezed,}) {
+  return _then(_FieldFilter(
+freezed == supported_features ? _self._supported_features : supported_features // ignore: cast_nullable_to_non_nullable
+as List<int>?,freezed == attribute ? _self._attribute : attribute // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,
+  ));
 }
+
+
+}
+
 
 /// @nodoc
 mixin _$Response {
-  bool get optional;
 
-  /// Create a copy of Response
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $ResponseCopyWith<Response> get copyWith =>
-      _$ResponseCopyWithImpl<Response>(this as Response, _$identity);
+ bool get optional;
+/// Create a copy of Response
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ResponseCopyWith<Response> get copyWith => _$ResponseCopyWithImpl<Response>(this as Response, _$identity);
 
   /// Serializes this Response to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is Response &&
-            (identical(other.optional, optional) ||
-                other.optional == optional));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(runtimeType, optional);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Response&&(identical(other.optional, optional) || other.optional == optional));
+}
 
-  @override
-  String toString() {
-    return 'Response(optional: $optional)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,optional);
+
+@override
+String toString() {
+  return 'Response(optional: $optional)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $ResponseCopyWith<$Res> {
-  factory $ResponseCopyWith(Response value, $Res Function(Response) _then) =
-      _$ResponseCopyWithImpl;
-  @useResult
-  $Res call({bool optional});
-}
+abstract mixin class $ResponseCopyWith<$Res>  {
+  factory $ResponseCopyWith(Response value, $Res Function(Response) _then) = _$ResponseCopyWithImpl;
+@useResult
+$Res call({
+ bool optional
+});
 
+
+
+
+}
 /// @nodoc
-class _$ResponseCopyWithImpl<$Res> implements $ResponseCopyWith<$Res> {
+class _$ResponseCopyWithImpl<$Res>
+    implements $ResponseCopyWith<$Res> {
   _$ResponseCopyWithImpl(this._self, this._then);
 
   final Response _self;
   final $Res Function(Response) _then;
 
-  /// Create a copy of Response
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? optional = null,
-  }) {
-    return _then(_self.copyWith(
-      optional: null == optional
-          ? _self.optional
-          : optional // ignore: cast_nullable_to_non_nullable
-              as bool,
-    ));
-  }
+/// Create a copy of Response
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? optional = null,}) {
+  return _then(_self.copyWith(
+optional: null == optional ? _self.optional : optional // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
 }
+
+}
+
 
 /// Adds pattern-matching-related methods to [Response].
 extension ResponsePatterns on Response {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_Response value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _Response() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Response value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Response() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_Response value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _Response():
-        return $default(_that);
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Response value)  $default,){
+final _that = this;
+switch (_that) {
+case _Response():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Response value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Response() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_Response value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _Response() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool optional)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Response() when $default != null:
+return $default(_that.optional);case _:
+  return orElse();
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(bool optional)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _Response() when $default != null:
-        return $default(_that.optional);
-      case _:
-        return orElse();
-    }
-  }
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool optional)  $default,) {final _that = this;
+switch (_that) {
+case _Response():
+return $default(_that.optional);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(bool optional) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _Response():
-        return $default(_that.optional);
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool optional)?  $default,) {final _that = this;
+switch (_that) {
+case _Response() when $default != null:
+return $default(_that.optional);case _:
+  return null;
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(bool optional)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _Response() when $default != null:
-        return $default(_that.optional);
-      case _:
-        return null;
-    }
-  }
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _Response implements Response {
   const _Response({required this.optional});
-  factory _Response.fromJson(Map<String, dynamic> json) =>
-      _$ResponseFromJson(json);
+  factory _Response.fromJson(Map<String, dynamic> json) => _$ResponseFromJson(json);
 
-  @override
-  final bool optional;
+@override final  bool optional;
 
-  /// Create a copy of Response
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$ResponseCopyWith<_Response> get copyWith =>
-      __$ResponseCopyWithImpl<_Response>(this, _$identity);
+/// Create a copy of Response
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ResponseCopyWith<_Response> get copyWith => __$ResponseCopyWithImpl<_Response>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$ResponseToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$ResponseToJson(this, );
+}
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _Response &&
-            (identical(other.optional, optional) ||
-                other.optional == optional));
-  }
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Response&&(identical(other.optional, optional) || other.optional == optional));
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(runtimeType, optional);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,optional);
 
-  @override
-  String toString() {
-    return 'Response(optional: $optional)';
-  }
+@override
+String toString() {
+  return 'Response(optional: $optional)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class _$ResponseCopyWith<$Res>
-    implements $ResponseCopyWith<$Res> {
-  factory _$ResponseCopyWith(_Response value, $Res Function(_Response) _then) =
-      __$ResponseCopyWithImpl;
-  @override
-  @useResult
-  $Res call({bool optional});
-}
+abstract mixin class _$ResponseCopyWith<$Res> implements $ResponseCopyWith<$Res> {
+  factory _$ResponseCopyWith(_Response value, $Res Function(_Response) _then) = __$ResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ bool optional
+});
 
+
+
+
+}
 /// @nodoc
-class __$ResponseCopyWithImpl<$Res> implements _$ResponseCopyWith<$Res> {
+class __$ResponseCopyWithImpl<$Res>
+    implements _$ResponseCopyWith<$Res> {
   __$ResponseCopyWithImpl(this._self, this._then);
 
   final _Response _self;
   final $Res Function(_Response) _then;
 
-  /// Create a copy of Response
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? optional = null,
-  }) {
-    return _then(_Response(
-      optional: null == optional
-          ? _self.optional
-          : optional // ignore: cast_nullable_to_non_nullable
-              as bool,
-    ));
-  }
+/// Create a copy of Response
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? optional = null,}) {
+  return _then(_Response(
+optional: null == optional ? _self.optional : optional // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+
 }
 
 // dart format on

--- a/packages/home_assistant_websocket/lib/src/types/hass_service.g.dart
+++ b/packages/home_assistant_websocket/lib/src/types/hass_service.g.dart
@@ -29,7 +29,7 @@ Map<String, dynamic> _$HassServicesToJson(_HassServices instance) =>
 
 _HassService _$HassServiceFromJson(Map<String, dynamic> json) => _HassService(
   name: json['name'] as String?,
-  description: json['description'] as String,
+  description: json['description'] as String?,
   target: json['target'] as Map<String, dynamic>?,
   fields: (json['fields'] as Map<String, dynamic>).map(
     (k, e) => MapEntry(k, Field.fromJson(e as Map<String, dynamic>)),

--- a/packages/home_assistant_websocket/lib/src/types/hass_types.freezed.dart
+++ b/packages/home_assistant_websocket/lib/src/types/hass_types.freezed.dart
@@ -11,722 +11,591 @@ part of 'hass_types.dart';
 
 // dart format off
 T _$identity<T>(T value) => value;
-HassError _$HassErrorFromJson(Map<String, dynamic> json) {
-  return _Error.fromJson(json);
+HassError _$HassErrorFromJson(
+  Map<String, dynamic> json
+) {
+    return _Error.fromJson(
+      json
+    );
 }
 
 /// @nodoc
 mixin _$HassError {
-  String get code;
-  String get message;
 
-  /// Create a copy of HassError
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $HassErrorCopyWith<HassError> get copyWith =>
-      _$HassErrorCopyWithImpl<HassError>(this as HassError, _$identity);
+ String get code; String get message;
+/// Create a copy of HassError
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$HassErrorCopyWith<HassError> get copyWith => _$HassErrorCopyWithImpl<HassError>(this as HassError, _$identity);
 
   /// Serializes this HassError to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is HassError &&
-            (identical(other.code, code) || other.code == code) &&
-            (identical(other.message, message) || other.message == message));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(runtimeType, code, message);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is HassError&&(identical(other.code, code) || other.code == code)&&(identical(other.message, message) || other.message == message));
+}
 
-  @override
-  String toString() {
-    return 'HassError(code: $code, message: $message)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,code,message);
+
+@override
+String toString() {
+  return 'HassError(code: $code, message: $message)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $HassErrorCopyWith<$Res> {
-  factory $HassErrorCopyWith(HassError value, $Res Function(HassError) _then) =
-      _$HassErrorCopyWithImpl;
-  @useResult
-  $Res call({String code, String message});
-}
+abstract mixin class $HassErrorCopyWith<$Res>  {
+  factory $HassErrorCopyWith(HassError value, $Res Function(HassError) _then) = _$HassErrorCopyWithImpl;
+@useResult
+$Res call({
+ String code, String message
+});
 
+
+
+
+}
 /// @nodoc
-class _$HassErrorCopyWithImpl<$Res> implements $HassErrorCopyWith<$Res> {
+class _$HassErrorCopyWithImpl<$Res>
+    implements $HassErrorCopyWith<$Res> {
   _$HassErrorCopyWithImpl(this._self, this._then);
 
   final HassError _self;
   final $Res Function(HassError) _then;
 
-  /// Create a copy of HassError
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? code = null,
-    Object? message = null,
-  }) {
-    return _then(_self.copyWith(
-      code: null == code
-          ? _self.code
-          : code // ignore: cast_nullable_to_non_nullable
-              as String,
-      message: null == message
-          ? _self.message
-          : message // ignore: cast_nullable_to_non_nullable
-              as String,
-    ));
-  }
+/// Create a copy of HassError
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? code = null,Object? message = null,}) {
+  return _then(_self.copyWith(
+code: null == code ? _self.code : code // ignore: cast_nullable_to_non_nullable
+as String,message: null == message ? _self.message : message // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
 }
+
+}
+
 
 /// Adds pattern-matching-related methods to [HassError].
 extension HassErrorPatterns on HassError {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_Error value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _Error() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Error value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Error() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_Error value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _Error():
-        return $default(_that);
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Error value)  $default,){
+final _that = this;
+switch (_that) {
+case _Error():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Error value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Error() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_Error value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _Error() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String code,  String message)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Error() when $default != null:
+return $default(_that.code,_that.message);case _:
+  return orElse();
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(String code, String message)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _Error() when $default != null:
-        return $default(_that.code, _that.message);
-      case _:
-        return orElse();
-    }
-  }
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String code,  String message)  $default,) {final _that = this;
+switch (_that) {
+case _Error():
+return $default(_that.code,_that.message);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(String code, String message) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _Error():
-        return $default(_that.code, _that.message);
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String code,  String message)?  $default,) {final _that = this;
+switch (_that) {
+case _Error() when $default != null:
+return $default(_that.code,_that.message);case _:
+  return null;
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(String code, String message)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _Error() when $default != null:
-        return $default(_that.code, _that.message);
-      case _:
-        return null;
-    }
-  }
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _Error implements HassError {
   const _Error({required this.code, required this.message});
   factory _Error.fromJson(Map<String, dynamic> json) => _$ErrorFromJson(json);
 
-  @override
-  final String code;
-  @override
-  final String message;
+@override final  String code;
+@override final  String message;
 
-  /// Create a copy of HassError
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$ErrorCopyWith<_Error> get copyWith =>
-      __$ErrorCopyWithImpl<_Error>(this, _$identity);
+/// Create a copy of HassError
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ErrorCopyWith<_Error> get copyWith => __$ErrorCopyWithImpl<_Error>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$ErrorToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$ErrorToJson(this, );
+}
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _Error &&
-            (identical(other.code, code) || other.code == code) &&
-            (identical(other.message, message) || other.message == message));
-  }
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Error&&(identical(other.code, code) || other.code == code)&&(identical(other.message, message) || other.message == message));
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(runtimeType, code, message);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,code,message);
 
-  @override
-  String toString() {
-    return 'HassError(code: $code, message: $message)';
-  }
+@override
+String toString() {
+  return 'HassError(code: $code, message: $message)';
+}
+
+
 }
 
 /// @nodoc
 abstract mixin class _$ErrorCopyWith<$Res> implements $HassErrorCopyWith<$Res> {
-  factory _$ErrorCopyWith(_Error value, $Res Function(_Error) _then) =
-      __$ErrorCopyWithImpl;
-  @override
-  @useResult
-  $Res call({String code, String message});
-}
+  factory _$ErrorCopyWith(_Error value, $Res Function(_Error) _then) = __$ErrorCopyWithImpl;
+@override @useResult
+$Res call({
+ String code, String message
+});
 
+
+
+
+}
 /// @nodoc
-class __$ErrorCopyWithImpl<$Res> implements _$ErrorCopyWith<$Res> {
+class __$ErrorCopyWithImpl<$Res>
+    implements _$ErrorCopyWith<$Res> {
   __$ErrorCopyWithImpl(this._self, this._then);
 
   final _Error _self;
   final $Res Function(_Error) _then;
 
-  /// Create a copy of HassError
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? code = null,
-    Object? message = null,
-  }) {
-    return _then(_Error(
-      code: null == code
-          ? _self.code
-          : code // ignore: cast_nullable_to_non_nullable
-              as String,
-      message: null == message
-          ? _self.message
-          : message // ignore: cast_nullable_to_non_nullable
-              as String,
-    ));
-  }
+/// Create a copy of HassError
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? code = null,Object? message = null,}) {
+  return _then(_Error(
+code: null == code ? _self.code : code // ignore: cast_nullable_to_non_nullable
+as String,message: null == message ? _self.message : message // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
 }
+
+
+}
+
 
 /// @nodoc
 mixin _$AreaEntity {
-  String get area_id;
-  String get name;
-  String? get picture;
-  List<String>? get aliases;
 
-  /// Create a copy of AreaEntity
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $AreaEntityCopyWith<AreaEntity> get copyWith =>
-      _$AreaEntityCopyWithImpl<AreaEntity>(this as AreaEntity, _$identity);
+ String get area_id; String get name; String? get picture; List<String>? get aliases;
+/// Create a copy of AreaEntity
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$AreaEntityCopyWith<AreaEntity> get copyWith => _$AreaEntityCopyWithImpl<AreaEntity>(this as AreaEntity, _$identity);
 
   /// Serializes this AreaEntity to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is AreaEntity &&
-            (identical(other.area_id, area_id) || other.area_id == area_id) &&
-            (identical(other.name, name) || other.name == name) &&
-            (identical(other.picture, picture) || other.picture == picture) &&
-            const DeepCollectionEquality().equals(other.aliases, aliases));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(runtimeType, area_id, name, picture,
-      const DeepCollectionEquality().hash(aliases));
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AreaEntity&&(identical(other.area_id, area_id) || other.area_id == area_id)&&(identical(other.name, name) || other.name == name)&&(identical(other.picture, picture) || other.picture == picture)&&const DeepCollectionEquality().equals(other.aliases, aliases));
+}
 
-  @override
-  String toString() {
-    return 'AreaEntity(area_id: $area_id, name: $name, picture: $picture, aliases: $aliases)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,area_id,name,picture,const DeepCollectionEquality().hash(aliases));
+
+@override
+String toString() {
+  return 'AreaEntity(area_id: $area_id, name: $name, picture: $picture, aliases: $aliases)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $AreaEntityCopyWith<$Res> {
-  factory $AreaEntityCopyWith(
-          AreaEntity value, $Res Function(AreaEntity) _then) =
-      _$AreaEntityCopyWithImpl;
-  @useResult
-  $Res call(
-      {String area_id, String name, String? picture, List<String>? aliases});
-}
+abstract mixin class $AreaEntityCopyWith<$Res>  {
+  factory $AreaEntityCopyWith(AreaEntity value, $Res Function(AreaEntity) _then) = _$AreaEntityCopyWithImpl;
+@useResult
+$Res call({
+ String area_id, String name, String? picture, List<String>? aliases
+});
 
+
+
+
+}
 /// @nodoc
-class _$AreaEntityCopyWithImpl<$Res> implements $AreaEntityCopyWith<$Res> {
+class _$AreaEntityCopyWithImpl<$Res>
+    implements $AreaEntityCopyWith<$Res> {
   _$AreaEntityCopyWithImpl(this._self, this._then);
 
   final AreaEntity _self;
   final $Res Function(AreaEntity) _then;
 
-  /// Create a copy of AreaEntity
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? area_id = null,
-    Object? name = null,
-    Object? picture = freezed,
-    Object? aliases = freezed,
-  }) {
-    return _then(_self.copyWith(
-      area_id: null == area_id
-          ? _self.area_id
-          : area_id // ignore: cast_nullable_to_non_nullable
-              as String,
-      name: null == name
-          ? _self.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String,
-      picture: freezed == picture
-          ? _self.picture
-          : picture // ignore: cast_nullable_to_non_nullable
-              as String?,
-      aliases: freezed == aliases
-          ? _self.aliases
-          : aliases // ignore: cast_nullable_to_non_nullable
-              as List<String>?,
-    ));
-  }
+/// Create a copy of AreaEntity
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? area_id = null,Object? name = null,Object? picture = freezed,Object? aliases = freezed,}) {
+  return _then(_self.copyWith(
+area_id: null == area_id ? _self.area_id : area_id // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,picture: freezed == picture ? _self.picture : picture // ignore: cast_nullable_to_non_nullable
+as String?,aliases: freezed == aliases ? _self.aliases : aliases // ignore: cast_nullable_to_non_nullable
+as List<String>?,
+  ));
 }
+
+}
+
 
 /// Adds pattern-matching-related methods to [AreaEntity].
 extension AreaEntityPatterns on AreaEntity {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_AreaEntity value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _AreaEntity() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _AreaEntity value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _AreaEntity() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_AreaEntity value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _AreaEntity():
-        return $default(_that);
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _AreaEntity value)  $default,){
+final _that = this;
+switch (_that) {
+case _AreaEntity():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _AreaEntity value)?  $default,){
+final _that = this;
+switch (_that) {
+case _AreaEntity() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_AreaEntity value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _AreaEntity() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String area_id,  String name,  String? picture,  List<String>? aliases)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _AreaEntity() when $default != null:
+return $default(_that.area_id,_that.name,_that.picture,_that.aliases);case _:
+  return orElse();
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(String area_id, String name, String? picture,
-            List<String>? aliases)?
-        $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _AreaEntity() when $default != null:
-        return $default(
-            _that.area_id, _that.name, _that.picture, _that.aliases);
-      case _:
-        return orElse();
-    }
-  }
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String area_id,  String name,  String? picture,  List<String>? aliases)  $default,) {final _that = this;
+switch (_that) {
+case _AreaEntity():
+return $default(_that.area_id,_that.name,_that.picture,_that.aliases);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(
-            String area_id, String name, String? picture, List<String>? aliases)
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _AreaEntity():
-        return $default(
-            _that.area_id, _that.name, _that.picture, _that.aliases);
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String area_id,  String name,  String? picture,  List<String>? aliases)?  $default,) {final _that = this;
+switch (_that) {
+case _AreaEntity() when $default != null:
+return $default(_that.area_id,_that.name,_that.picture,_that.aliases);case _:
+  return null;
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(String area_id, String name, String? picture,
-            List<String>? aliases)?
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _AreaEntity() when $default != null:
-        return $default(
-            _that.area_id, _that.name, _that.picture, _that.aliases);
-      case _:
-        return null;
-    }
-  }
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _AreaEntity implements AreaEntity {
-  const _AreaEntity(
-      {required this.area_id,
-      required this.name,
-      this.picture,
-      final List<String>? aliases})
-      : _aliases = aliases;
-  factory _AreaEntity.fromJson(Map<String, dynamic> json) =>
-      _$AreaEntityFromJson(json);
+  const _AreaEntity({required this.area_id, required this.name, this.picture, final  List<String>? aliases}): _aliases = aliases;
+  factory _AreaEntity.fromJson(Map<String, dynamic> json) => _$AreaEntityFromJson(json);
 
-  @override
-  final String area_id;
-  @override
-  final String name;
-  @override
-  final String? picture;
-  final List<String>? _aliases;
-  @override
-  List<String>? get aliases {
-    final value = _aliases;
-    if (value == null) return null;
-    if (_aliases is EqualUnmodifiableListView) return _aliases;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(value);
-  }
+@override final  String area_id;
+@override final  String name;
+@override final  String? picture;
+ final  List<String>? _aliases;
+@override List<String>? get aliases {
+  final value = _aliases;
+  if (value == null) return null;
+  if (_aliases is EqualUnmodifiableListView) return _aliases;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
+}
 
-  /// Create a copy of AreaEntity
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$AreaEntityCopyWith<_AreaEntity> get copyWith =>
-      __$AreaEntityCopyWithImpl<_AreaEntity>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$AreaEntityToJson(
-      this,
-    );
-  }
+/// Create a copy of AreaEntity
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$AreaEntityCopyWith<_AreaEntity> get copyWith => __$AreaEntityCopyWithImpl<_AreaEntity>(this, _$identity);
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _AreaEntity &&
-            (identical(other.area_id, area_id) || other.area_id == area_id) &&
-            (identical(other.name, name) || other.name == name) &&
-            (identical(other.picture, picture) || other.picture == picture) &&
-            const DeepCollectionEquality().equals(other._aliases, _aliases));
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$AreaEntityToJson(this, );
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(runtimeType, area_id, name, picture,
-      const DeepCollectionEquality().hash(_aliases));
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _AreaEntity&&(identical(other.area_id, area_id) || other.area_id == area_id)&&(identical(other.name, name) || other.name == name)&&(identical(other.picture, picture) || other.picture == picture)&&const DeepCollectionEquality().equals(other._aliases, _aliases));
+}
 
-  @override
-  String toString() {
-    return 'AreaEntity(area_id: $area_id, name: $name, picture: $picture, aliases: $aliases)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,area_id,name,picture,const DeepCollectionEquality().hash(_aliases));
+
+@override
+String toString() {
+  return 'AreaEntity(area_id: $area_id, name: $name, picture: $picture, aliases: $aliases)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class _$AreaEntityCopyWith<$Res>
-    implements $AreaEntityCopyWith<$Res> {
-  factory _$AreaEntityCopyWith(
-          _AreaEntity value, $Res Function(_AreaEntity) _then) =
-      __$AreaEntityCopyWithImpl;
-  @override
-  @useResult
-  $Res call(
-      {String area_id, String name, String? picture, List<String>? aliases});
-}
+abstract mixin class _$AreaEntityCopyWith<$Res> implements $AreaEntityCopyWith<$Res> {
+  factory _$AreaEntityCopyWith(_AreaEntity value, $Res Function(_AreaEntity) _then) = __$AreaEntityCopyWithImpl;
+@override @useResult
+$Res call({
+ String area_id, String name, String? picture, List<String>? aliases
+});
 
+
+
+
+}
 /// @nodoc
-class __$AreaEntityCopyWithImpl<$Res> implements _$AreaEntityCopyWith<$Res> {
+class __$AreaEntityCopyWithImpl<$Res>
+    implements _$AreaEntityCopyWith<$Res> {
   __$AreaEntityCopyWithImpl(this._self, this._then);
 
   final _AreaEntity _self;
   final $Res Function(_AreaEntity) _then;
 
-  /// Create a copy of AreaEntity
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? area_id = null,
-    Object? name = null,
-    Object? picture = freezed,
-    Object? aliases = freezed,
-  }) {
-    return _then(_AreaEntity(
-      area_id: null == area_id
-          ? _self.area_id
-          : area_id // ignore: cast_nullable_to_non_nullable
-              as String,
-      name: null == name
-          ? _self.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String,
-      picture: freezed == picture
-          ? _self.picture
-          : picture // ignore: cast_nullable_to_non_nullable
-              as String?,
-      aliases: freezed == aliases
-          ? _self._aliases
-          : aliases // ignore: cast_nullable_to_non_nullable
-              as List<String>?,
-    ));
-  }
+/// Create a copy of AreaEntity
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? area_id = null,Object? name = null,Object? picture = freezed,Object? aliases = freezed,}) {
+  return _then(_AreaEntity(
+area_id: null == area_id ? _self.area_id : area_id // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,picture: freezed == picture ? _self.picture : picture // ignore: cast_nullable_to_non_nullable
+as String?,aliases: freezed == aliases ? _self._aliases : aliases // ignore: cast_nullable_to_non_nullable
+as List<String>?,
+  ));
 }
+
+
+}
+
 
 /// @nodoc
 mixin _$AreaEntityList {
-  List<AreaEntity> get areasList;
 
-  /// Create a copy of AreaEntityList
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $AreaEntityListCopyWith<AreaEntityList> get copyWith =>
-      _$AreaEntityListCopyWithImpl<AreaEntityList>(
-          this as AreaEntityList, _$identity);
+ List<AreaEntity> get areasList;
+/// Create a copy of AreaEntityList
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$AreaEntityListCopyWith<AreaEntityList> get copyWith => _$AreaEntityListCopyWithImpl<AreaEntityList>(this as AreaEntityList, _$identity);
 
   /// Serializes this AreaEntityList to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is AreaEntityList &&
-            const DeepCollectionEquality().equals(other.areasList, areasList));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode =>
-      Object.hash(runtimeType, const DeepCollectionEquality().hash(areasList));
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AreaEntityList&&const DeepCollectionEquality().equals(other.areasList, areasList));
+}
 
-  @override
-  String toString() {
-    return 'AreaEntityList(areasList: $areasList)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(areasList));
+
+@override
+String toString() {
+  return 'AreaEntityList(areasList: $areasList)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $AreaEntityListCopyWith<$Res> {
-  factory $AreaEntityListCopyWith(
-          AreaEntityList value, $Res Function(AreaEntityList) _then) =
-      _$AreaEntityListCopyWithImpl;
-  @useResult
-  $Res call({List<AreaEntity> areasList});
-}
+abstract mixin class $AreaEntityListCopyWith<$Res>  {
+  factory $AreaEntityListCopyWith(AreaEntityList value, $Res Function(AreaEntityList) _then) = _$AreaEntityListCopyWithImpl;
+@useResult
+$Res call({
+ List<AreaEntity> areasList
+});
 
+
+
+
+}
 /// @nodoc
 class _$AreaEntityListCopyWithImpl<$Res>
     implements $AreaEntityListCopyWith<$Res> {
@@ -735,237 +604,197 @@ class _$AreaEntityListCopyWithImpl<$Res>
   final AreaEntityList _self;
   final $Res Function(AreaEntityList) _then;
 
-  /// Create a copy of AreaEntityList
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? areasList = null,
-  }) {
-    return _then(_self.copyWith(
-      areasList: null == areasList
-          ? _self.areasList
-          : areasList // ignore: cast_nullable_to_non_nullable
-              as List<AreaEntity>,
-    ));
-  }
+/// Create a copy of AreaEntityList
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? areasList = null,}) {
+  return _then(_self.copyWith(
+areasList: null == areasList ? _self.areasList : areasList // ignore: cast_nullable_to_non_nullable
+as List<AreaEntity>,
+  ));
 }
+
+}
+
 
 /// Adds pattern-matching-related methods to [AreaEntityList].
 extension AreaEntityListPatterns on AreaEntityList {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_AreaEntityList value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _AreaEntityList() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _AreaEntityList value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _AreaEntityList() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_AreaEntityList value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _AreaEntityList():
-        return $default(_that);
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _AreaEntityList value)  $default,){
+final _that = this;
+switch (_that) {
+case _AreaEntityList():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _AreaEntityList value)?  $default,){
+final _that = this;
+switch (_that) {
+case _AreaEntityList() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_AreaEntityList value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _AreaEntityList() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( List<AreaEntity> areasList)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _AreaEntityList() when $default != null:
+return $default(_that.areasList);case _:
+  return orElse();
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(List<AreaEntity> areasList)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _AreaEntityList() when $default != null:
-        return $default(_that.areasList);
-      case _:
-        return orElse();
-    }
-  }
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( List<AreaEntity> areasList)  $default,) {final _that = this;
+switch (_that) {
+case _AreaEntityList():
+return $default(_that.areasList);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(List<AreaEntity> areasList) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _AreaEntityList():
-        return $default(_that.areasList);
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( List<AreaEntity> areasList)?  $default,) {final _that = this;
+switch (_that) {
+case _AreaEntityList() when $default != null:
+return $default(_that.areasList);case _:
+  return null;
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(List<AreaEntity> areasList)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _AreaEntityList() when $default != null:
-        return $default(_that.areasList);
-      case _:
-        return null;
-    }
-  }
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _AreaEntityList implements AreaEntityList {
-  const _AreaEntityList(final List<AreaEntity> areasList)
-      : _areasList = areasList;
-  factory _AreaEntityList.fromJson(Map<String, dynamic> json) =>
-      _$AreaEntityListFromJson(json);
+  const _AreaEntityList(final  List<AreaEntity> areasList): _areasList = areasList;
+  factory _AreaEntityList.fromJson(Map<String, dynamic> json) => _$AreaEntityListFromJson(json);
 
-  final List<AreaEntity> _areasList;
-  @override
-  List<AreaEntity> get areasList {
-    if (_areasList is EqualUnmodifiableListView) return _areasList;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_areasList);
-  }
+ final  List<AreaEntity> _areasList;
+@override List<AreaEntity> get areasList {
+  if (_areasList is EqualUnmodifiableListView) return _areasList;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_areasList);
+}
 
-  /// Create a copy of AreaEntityList
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$AreaEntityListCopyWith<_AreaEntityList> get copyWith =>
-      __$AreaEntityListCopyWithImpl<_AreaEntityList>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$AreaEntityListToJson(
-      this,
-    );
-  }
+/// Create a copy of AreaEntityList
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$AreaEntityListCopyWith<_AreaEntityList> get copyWith => __$AreaEntityListCopyWithImpl<_AreaEntityList>(this, _$identity);
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _AreaEntityList &&
-            const DeepCollectionEquality()
-                .equals(other._areasList, _areasList));
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$AreaEntityListToJson(this, );
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode =>
-      Object.hash(runtimeType, const DeepCollectionEquality().hash(_areasList));
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _AreaEntityList&&const DeepCollectionEquality().equals(other._areasList, _areasList));
+}
 
-  @override
-  String toString() {
-    return 'AreaEntityList(areasList: $areasList)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_areasList));
+
+@override
+String toString() {
+  return 'AreaEntityList(areasList: $areasList)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class _$AreaEntityListCopyWith<$Res>
-    implements $AreaEntityListCopyWith<$Res> {
-  factory _$AreaEntityListCopyWith(
-          _AreaEntityList value, $Res Function(_AreaEntityList) _then) =
-      __$AreaEntityListCopyWithImpl;
-  @override
-  @useResult
-  $Res call({List<AreaEntity> areasList});
-}
+abstract mixin class _$AreaEntityListCopyWith<$Res> implements $AreaEntityListCopyWith<$Res> {
+  factory _$AreaEntityListCopyWith(_AreaEntityList value, $Res Function(_AreaEntityList) _then) = __$AreaEntityListCopyWithImpl;
+@override @useResult
+$Res call({
+ List<AreaEntity> areasList
+});
 
+
+
+
+}
 /// @nodoc
 class __$AreaEntityListCopyWithImpl<$Res>
     implements _$AreaEntityListCopyWith<$Res> {
@@ -974,1788 +803,929 @@ class __$AreaEntityListCopyWithImpl<$Res>
   final _AreaEntityList _self;
   final $Res Function(_AreaEntityList) _then;
 
-  /// Create a copy of AreaEntityList
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? areasList = null,
-  }) {
-    return _then(_AreaEntityList(
-      null == areasList
-          ? _self._areasList
-          : areasList // ignore: cast_nullable_to_non_nullable
-              as List<AreaEntity>,
-    ));
-  }
+/// Create a copy of AreaEntityList
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? areasList = null,}) {
+  return _then(_AreaEntityList(
+null == areasList ? _self._areasList : areasList // ignore: cast_nullable_to_non_nullable
+as List<AreaEntity>,
+  ));
 }
+
+
+}
+
 
 /// @nodoc
 mixin _$HassUser {
-  String get id;
-  bool get is_admin;
-  bool get is_owner;
-  String get name;
 
-  /// Create a copy of HassUser
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $HassUserCopyWith<HassUser> get copyWith =>
-      _$HassUserCopyWithImpl<HassUser>(this as HassUser, _$identity);
+ String get id; bool get is_admin; bool get is_owner; String get name;
+/// Create a copy of HassUser
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$HassUserCopyWith<HassUser> get copyWith => _$HassUserCopyWithImpl<HassUser>(this as HassUser, _$identity);
 
   /// Serializes this HassUser to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is HassUser &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.is_admin, is_admin) ||
-                other.is_admin == is_admin) &&
-            (identical(other.is_owner, is_owner) ||
-                other.is_owner == is_owner) &&
-            (identical(other.name, name) || other.name == name));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(runtimeType, id, is_admin, is_owner, name);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is HassUser&&(identical(other.id, id) || other.id == id)&&(identical(other.is_admin, is_admin) || other.is_admin == is_admin)&&(identical(other.is_owner, is_owner) || other.is_owner == is_owner)&&(identical(other.name, name) || other.name == name));
+}
 
-  @override
-  String toString() {
-    return 'HassUser(id: $id, is_admin: $is_admin, is_owner: $is_owner, name: $name)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,is_admin,is_owner,name);
+
+@override
+String toString() {
+  return 'HassUser(id: $id, is_admin: $is_admin, is_owner: $is_owner, name: $name)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $HassUserCopyWith<$Res> {
-  factory $HassUserCopyWith(HassUser value, $Res Function(HassUser) _then) =
-      _$HassUserCopyWithImpl;
-  @useResult
-  $Res call({String id, bool is_admin, bool is_owner, String name});
-}
+abstract mixin class $HassUserCopyWith<$Res>  {
+  factory $HassUserCopyWith(HassUser value, $Res Function(HassUser) _then) = _$HassUserCopyWithImpl;
+@useResult
+$Res call({
+ String id, bool is_admin, bool is_owner, String name
+});
 
+
+
+
+}
 /// @nodoc
-class _$HassUserCopyWithImpl<$Res> implements $HassUserCopyWith<$Res> {
+class _$HassUserCopyWithImpl<$Res>
+    implements $HassUserCopyWith<$Res> {
   _$HassUserCopyWithImpl(this._self, this._then);
 
   final HassUser _self;
   final $Res Function(HassUser) _then;
 
-  /// Create a copy of HassUser
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? id = null,
-    Object? is_admin = null,
-    Object? is_owner = null,
-    Object? name = null,
-  }) {
-    return _then(_self.copyWith(
-      id: null == id
-          ? _self.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      is_admin: null == is_admin
-          ? _self.is_admin
-          : is_admin // ignore: cast_nullable_to_non_nullable
-              as bool,
-      is_owner: null == is_owner
-          ? _self.is_owner
-          : is_owner // ignore: cast_nullable_to_non_nullable
-              as bool,
-      name: null == name
-          ? _self.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String,
-    ));
-  }
+/// Create a copy of HassUser
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? is_admin = null,Object? is_owner = null,Object? name = null,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,is_admin: null == is_admin ? _self.is_admin : is_admin // ignore: cast_nullable_to_non_nullable
+as bool,is_owner: null == is_owner ? _self.is_owner : is_owner // ignore: cast_nullable_to_non_nullable
+as bool,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
 }
+
+}
+
 
 /// Adds pattern-matching-related methods to [HassUser].
 extension HassUserPatterns on HassUser {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_HassUser value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _HassUser() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _HassUser value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _HassUser() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_HassUser value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _HassUser():
-        return $default(_that);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _HassUser value)  $default,){
+final _that = this;
+switch (_that) {
+case _HassUser():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_HassUser value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _HassUser() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _HassUser value)?  $default,){
+final _that = this;
+switch (_that) {
+case _HassUser() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(String id, bool is_admin, bool is_owner, String name)?
-        $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _HassUser() when $default != null:
-        return $default(_that.id, _that.is_admin, _that.is_owner, _that.name);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  bool is_admin,  bool is_owner,  String name)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _HassUser() when $default != null:
+return $default(_that.id,_that.is_admin,_that.is_owner,_that.name);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(String id, bool is_admin, bool is_owner, String name)
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _HassUser():
-        return $default(_that.id, _that.is_admin, _that.is_owner, _that.name);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  bool is_admin,  bool is_owner,  String name)  $default,) {final _that = this;
+switch (_that) {
+case _HassUser():
+return $default(_that.id,_that.is_admin,_that.is_owner,_that.name);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(String id, bool is_admin, bool is_owner, String name)?
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _HassUser() when $default != null:
-        return $default(_that.id, _that.is_admin, _that.is_owner, _that.name);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  bool is_admin,  bool is_owner,  String name)?  $default,) {final _that = this;
+switch (_that) {
+case _HassUser() when $default != null:
+return $default(_that.id,_that.is_admin,_that.is_owner,_that.name);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _HassUser implements HassUser {
-  const _HassUser(
-      {required this.id,
-      required this.is_admin,
-      required this.is_owner,
-      required this.name});
-  factory _HassUser.fromJson(Map<String, dynamic> json) =>
-      _$HassUserFromJson(json);
+  const _HassUser({required this.id, required this.is_admin, required this.is_owner, required this.name});
+  factory _HassUser.fromJson(Map<String, dynamic> json) => _$HassUserFromJson(json);
 
-  @override
-  final String id;
-  @override
-  final bool is_admin;
-  @override
-  final bool is_owner;
-  @override
-  final String name;
+@override final  String id;
+@override final  bool is_admin;
+@override final  bool is_owner;
+@override final  String name;
 
-  /// Create a copy of HassUser
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$HassUserCopyWith<_HassUser> get copyWith =>
-      __$HassUserCopyWithImpl<_HassUser>(this, _$identity);
+/// Create a copy of HassUser
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$HassUserCopyWith<_HassUser> get copyWith => __$HassUserCopyWithImpl<_HassUser>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$HassUserToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$HassUserToJson(this, );
+}
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _HassUser &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.is_admin, is_admin) ||
-                other.is_admin == is_admin) &&
-            (identical(other.is_owner, is_owner) ||
-                other.is_owner == is_owner) &&
-            (identical(other.name, name) || other.name == name));
-  }
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _HassUser&&(identical(other.id, id) || other.id == id)&&(identical(other.is_admin, is_admin) || other.is_admin == is_admin)&&(identical(other.is_owner, is_owner) || other.is_owner == is_owner)&&(identical(other.name, name) || other.name == name));
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(runtimeType, id, is_admin, is_owner, name);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,is_admin,is_owner,name);
 
-  @override
-  String toString() {
-    return 'HassUser(id: $id, is_admin: $is_admin, is_owner: $is_owner, name: $name)';
-  }
+@override
+String toString() {
+  return 'HassUser(id: $id, is_admin: $is_admin, is_owner: $is_owner, name: $name)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class _$HassUserCopyWith<$Res>
-    implements $HassUserCopyWith<$Res> {
-  factory _$HassUserCopyWith(_HassUser value, $Res Function(_HassUser) _then) =
-      __$HassUserCopyWithImpl;
-  @override
-  @useResult
-  $Res call({String id, bool is_admin, bool is_owner, String name});
-}
+abstract mixin class _$HassUserCopyWith<$Res> implements $HassUserCopyWith<$Res> {
+  factory _$HassUserCopyWith(_HassUser value, $Res Function(_HassUser) _then) = __$HassUserCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, bool is_admin, bool is_owner, String name
+});
 
+
+
+
+}
 /// @nodoc
-class __$HassUserCopyWithImpl<$Res> implements _$HassUserCopyWith<$Res> {
+class __$HassUserCopyWithImpl<$Res>
+    implements _$HassUserCopyWith<$Res> {
   __$HassUserCopyWithImpl(this._self, this._then);
 
   final _HassUser _self;
   final $Res Function(_HassUser) _then;
 
-  /// Create a copy of HassUser
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? id = null,
-    Object? is_admin = null,
-    Object? is_owner = null,
-    Object? name = null,
-  }) {
-    return _then(_HassUser(
-      id: null == id
-          ? _self.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      is_admin: null == is_admin
-          ? _self.is_admin
-          : is_admin // ignore: cast_nullable_to_non_nullable
-              as bool,
-      is_owner: null == is_owner
-          ? _self.is_owner
-          : is_owner // ignore: cast_nullable_to_non_nullable
-              as bool,
-      name: null == name
-          ? _self.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String,
-    ));
-  }
+/// Create a copy of HassUser
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? is_admin = null,Object? is_owner = null,Object? name = null,}) {
+  return _then(_HassUser(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,is_admin: null == is_admin ? _self.is_admin : is_admin // ignore: cast_nullable_to_non_nullable
+as bool,is_owner: null == is_owner ? _self.is_owner : is_owner // ignore: cast_nullable_to_non_nullable
+as bool,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
 }
+
+
+}
+
 
 /// @nodoc
 mixin _$HassConfig {
-  double get latitude;
-  double get longitude;
-  double get elevation;
-  double get radius;
-  UnitSystem get unit_system;
-  String get location_name;
-  String get time_zone;
-  List<String> get components;
-  String get config_dir;
-  List<String> get allowlist_external_dirs;
-  List<String> get allowlist_external_urls;
-  String get version;
-  String get config_source;
-  bool get recovery_mode;
-  bool
-      get safe_mode; // @StringEnum('NOT_RUNNING', 'STARTING', 'RUNNING', 'STOPPING', 'FINAL_WRITE')
-  State get state;
-  String? get external_url;
-  String? get internal_url;
-  List<String>? get whitelist_external_dirs;
-  String get currency;
-  String? get country;
-  String get language;
 
-  /// Create a copy of HassConfig
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $HassConfigCopyWith<HassConfig> get copyWith =>
-      _$HassConfigCopyWithImpl<HassConfig>(this as HassConfig, _$identity);
+ double get latitude; double get longitude; double get elevation; double get radius; UnitSystem get unit_system; String get location_name; String get time_zone; List<String> get components; String get config_dir; List<String> get allowlist_external_dirs; List<String> get allowlist_external_urls; String get version; String get config_source; bool get recovery_mode; bool get safe_mode;// @StringEnum('NOT_RUNNING', 'STARTING', 'RUNNING', 'STOPPING', 'FINAL_WRITE')
+ State get state; String? get external_url; String? get internal_url; List<String>? get whitelist_external_dirs; String get currency; String? get country; String get language;
+/// Create a copy of HassConfig
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$HassConfigCopyWith<HassConfig> get copyWith => _$HassConfigCopyWithImpl<HassConfig>(this as HassConfig, _$identity);
 
   /// Serializes this HassConfig to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is HassConfig &&
-            (identical(other.latitude, latitude) ||
-                other.latitude == latitude) &&
-            (identical(other.longitude, longitude) ||
-                other.longitude == longitude) &&
-            (identical(other.elevation, elevation) ||
-                other.elevation == elevation) &&
-            (identical(other.radius, radius) || other.radius == radius) &&
-            (identical(other.unit_system, unit_system) ||
-                other.unit_system == unit_system) &&
-            (identical(other.location_name, location_name) ||
-                other.location_name == location_name) &&
-            (identical(other.time_zone, time_zone) ||
-                other.time_zone == time_zone) &&
-            const DeepCollectionEquality()
-                .equals(other.components, components) &&
-            (identical(other.config_dir, config_dir) ||
-                other.config_dir == config_dir) &&
-            const DeepCollectionEquality().equals(
-                other.allowlist_external_dirs, allowlist_external_dirs) &&
-            const DeepCollectionEquality().equals(
-                other.allowlist_external_urls, allowlist_external_urls) &&
-            (identical(other.version, version) || other.version == version) &&
-            (identical(other.config_source, config_source) ||
-                other.config_source == config_source) &&
-            (identical(other.recovery_mode, recovery_mode) ||
-                other.recovery_mode == recovery_mode) &&
-            (identical(other.safe_mode, safe_mode) ||
-                other.safe_mode == safe_mode) &&
-            (identical(other.state, state) || other.state == state) &&
-            (identical(other.external_url, external_url) ||
-                other.external_url == external_url) &&
-            (identical(other.internal_url, internal_url) ||
-                other.internal_url == internal_url) &&
-            const DeepCollectionEquality().equals(
-                other.whitelist_external_dirs, whitelist_external_dirs) &&
-            (identical(other.currency, currency) ||
-                other.currency == currency) &&
-            (identical(other.country, country) || other.country == country) &&
-            (identical(other.language, language) ||
-                other.language == language));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hashAll([
-        runtimeType,
-        latitude,
-        longitude,
-        elevation,
-        radius,
-        unit_system,
-        location_name,
-        time_zone,
-        const DeepCollectionEquality().hash(components),
-        config_dir,
-        const DeepCollectionEquality().hash(allowlist_external_dirs),
-        const DeepCollectionEquality().hash(allowlist_external_urls),
-        version,
-        config_source,
-        recovery_mode,
-        safe_mode,
-        state,
-        external_url,
-        internal_url,
-        const DeepCollectionEquality().hash(whitelist_external_dirs),
-        currency,
-        country,
-        language
-      ]);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is HassConfig&&(identical(other.latitude, latitude) || other.latitude == latitude)&&(identical(other.longitude, longitude) || other.longitude == longitude)&&(identical(other.elevation, elevation) || other.elevation == elevation)&&(identical(other.radius, radius) || other.radius == radius)&&(identical(other.unit_system, unit_system) || other.unit_system == unit_system)&&(identical(other.location_name, location_name) || other.location_name == location_name)&&(identical(other.time_zone, time_zone) || other.time_zone == time_zone)&&const DeepCollectionEquality().equals(other.components, components)&&(identical(other.config_dir, config_dir) || other.config_dir == config_dir)&&const DeepCollectionEquality().equals(other.allowlist_external_dirs, allowlist_external_dirs)&&const DeepCollectionEquality().equals(other.allowlist_external_urls, allowlist_external_urls)&&(identical(other.version, version) || other.version == version)&&(identical(other.config_source, config_source) || other.config_source == config_source)&&(identical(other.recovery_mode, recovery_mode) || other.recovery_mode == recovery_mode)&&(identical(other.safe_mode, safe_mode) || other.safe_mode == safe_mode)&&(identical(other.state, state) || other.state == state)&&(identical(other.external_url, external_url) || other.external_url == external_url)&&(identical(other.internal_url, internal_url) || other.internal_url == internal_url)&&const DeepCollectionEquality().equals(other.whitelist_external_dirs, whitelist_external_dirs)&&(identical(other.currency, currency) || other.currency == currency)&&(identical(other.country, country) || other.country == country)&&(identical(other.language, language) || other.language == language));
+}
 
-  @override
-  String toString() {
-    return 'HassConfig(latitude: $latitude, longitude: $longitude, elevation: $elevation, radius: $radius, unit_system: $unit_system, location_name: $location_name, time_zone: $time_zone, components: $components, config_dir: $config_dir, allowlist_external_dirs: $allowlist_external_dirs, allowlist_external_urls: $allowlist_external_urls, version: $version, config_source: $config_source, recovery_mode: $recovery_mode, safe_mode: $safe_mode, state: $state, external_url: $external_url, internal_url: $internal_url, whitelist_external_dirs: $whitelist_external_dirs, currency: $currency, country: $country, language: $language)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hashAll([runtimeType,latitude,longitude,elevation,radius,unit_system,location_name,time_zone,const DeepCollectionEquality().hash(components),config_dir,const DeepCollectionEquality().hash(allowlist_external_dirs),const DeepCollectionEquality().hash(allowlist_external_urls),version,config_source,recovery_mode,safe_mode,state,external_url,internal_url,const DeepCollectionEquality().hash(whitelist_external_dirs),currency,country,language]);
+
+@override
+String toString() {
+  return 'HassConfig(latitude: $latitude, longitude: $longitude, elevation: $elevation, radius: $radius, unit_system: $unit_system, location_name: $location_name, time_zone: $time_zone, components: $components, config_dir: $config_dir, allowlist_external_dirs: $allowlist_external_dirs, allowlist_external_urls: $allowlist_external_urls, version: $version, config_source: $config_source, recovery_mode: $recovery_mode, safe_mode: $safe_mode, state: $state, external_url: $external_url, internal_url: $internal_url, whitelist_external_dirs: $whitelist_external_dirs, currency: $currency, country: $country, language: $language)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $HassConfigCopyWith<$Res> {
-  factory $HassConfigCopyWith(
-          HassConfig value, $Res Function(HassConfig) _then) =
-      _$HassConfigCopyWithImpl;
-  @useResult
-  $Res call(
-      {double latitude,
-      double longitude,
-      double elevation,
-      double radius,
-      UnitSystem unit_system,
-      String location_name,
-      String time_zone,
-      List<String> components,
-      String config_dir,
-      List<String> allowlist_external_dirs,
-      List<String> allowlist_external_urls,
-      String version,
-      String config_source,
-      bool recovery_mode,
-      bool safe_mode,
-      State state,
-      String? external_url,
-      String? internal_url,
-      List<String>? whitelist_external_dirs,
-      String currency,
-      String? country,
-      String language});
+abstract mixin class $HassConfigCopyWith<$Res>  {
+  factory $HassConfigCopyWith(HassConfig value, $Res Function(HassConfig) _then) = _$HassConfigCopyWithImpl;
+@useResult
+$Res call({
+ double latitude, double longitude, double elevation, double radius, UnitSystem unit_system, String location_name, String time_zone, List<String> components, String config_dir, List<String> allowlist_external_dirs, List<String> allowlist_external_urls, String version, String config_source, bool recovery_mode, bool safe_mode, State state, String? external_url, String? internal_url, List<String>? whitelist_external_dirs, String currency, String? country, String language
+});
 
-  $UnitSystemCopyWith<$Res> get unit_system;
+
+$UnitSystemCopyWith<$Res> get unit_system;
+
 }
-
 /// @nodoc
-class _$HassConfigCopyWithImpl<$Res> implements $HassConfigCopyWith<$Res> {
+class _$HassConfigCopyWithImpl<$Res>
+    implements $HassConfigCopyWith<$Res> {
   _$HassConfigCopyWithImpl(this._self, this._then);
 
   final HassConfig _self;
   final $Res Function(HassConfig) _then;
 
-  /// Create a copy of HassConfig
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? latitude = null,
-    Object? longitude = null,
-    Object? elevation = null,
-    Object? radius = null,
-    Object? unit_system = null,
-    Object? location_name = null,
-    Object? time_zone = null,
-    Object? components = null,
-    Object? config_dir = null,
-    Object? allowlist_external_dirs = null,
-    Object? allowlist_external_urls = null,
-    Object? version = null,
-    Object? config_source = null,
-    Object? recovery_mode = null,
-    Object? safe_mode = null,
-    Object? state = null,
-    Object? external_url = freezed,
-    Object? internal_url = freezed,
-    Object? whitelist_external_dirs = freezed,
-    Object? currency = null,
-    Object? country = freezed,
-    Object? language = null,
-  }) {
-    return _then(_self.copyWith(
-      latitude: null == latitude
-          ? _self.latitude
-          : latitude // ignore: cast_nullable_to_non_nullable
-              as double,
-      longitude: null == longitude
-          ? _self.longitude
-          : longitude // ignore: cast_nullable_to_non_nullable
-              as double,
-      elevation: null == elevation
-          ? _self.elevation
-          : elevation // ignore: cast_nullable_to_non_nullable
-              as double,
-      radius: null == radius
-          ? _self.radius
-          : radius // ignore: cast_nullable_to_non_nullable
-              as double,
-      unit_system: null == unit_system
-          ? _self.unit_system
-          : unit_system // ignore: cast_nullable_to_non_nullable
-              as UnitSystem,
-      location_name: null == location_name
-          ? _self.location_name
-          : location_name // ignore: cast_nullable_to_non_nullable
-              as String,
-      time_zone: null == time_zone
-          ? _self.time_zone
-          : time_zone // ignore: cast_nullable_to_non_nullable
-              as String,
-      components: null == components
-          ? _self.components
-          : components // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-      config_dir: null == config_dir
-          ? _self.config_dir
-          : config_dir // ignore: cast_nullable_to_non_nullable
-              as String,
-      allowlist_external_dirs: null == allowlist_external_dirs
-          ? _self.allowlist_external_dirs
-          : allowlist_external_dirs // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-      allowlist_external_urls: null == allowlist_external_urls
-          ? _self.allowlist_external_urls
-          : allowlist_external_urls // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-      version: null == version
-          ? _self.version
-          : version // ignore: cast_nullable_to_non_nullable
-              as String,
-      config_source: null == config_source
-          ? _self.config_source
-          : config_source // ignore: cast_nullable_to_non_nullable
-              as String,
-      recovery_mode: null == recovery_mode
-          ? _self.recovery_mode
-          : recovery_mode // ignore: cast_nullable_to_non_nullable
-              as bool,
-      safe_mode: null == safe_mode
-          ? _self.safe_mode
-          : safe_mode // ignore: cast_nullable_to_non_nullable
-              as bool,
-      state: null == state
-          ? _self.state
-          : state // ignore: cast_nullable_to_non_nullable
-              as State,
-      external_url: freezed == external_url
-          ? _self.external_url
-          : external_url // ignore: cast_nullable_to_non_nullable
-              as String?,
-      internal_url: freezed == internal_url
-          ? _self.internal_url
-          : internal_url // ignore: cast_nullable_to_non_nullable
-              as String?,
-      whitelist_external_dirs: freezed == whitelist_external_dirs
-          ? _self.whitelist_external_dirs
-          : whitelist_external_dirs // ignore: cast_nullable_to_non_nullable
-              as List<String>?,
-      currency: null == currency
-          ? _self.currency
-          : currency // ignore: cast_nullable_to_non_nullable
-              as String,
-      country: freezed == country
-          ? _self.country
-          : country // ignore: cast_nullable_to_non_nullable
-              as String?,
-      language: null == language
-          ? _self.language
-          : language // ignore: cast_nullable_to_non_nullable
-              as String,
-    ));
-  }
-
-  /// Create a copy of HassConfig
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $UnitSystemCopyWith<$Res> get unit_system {
-    return $UnitSystemCopyWith<$Res>(_self.unit_system, (value) {
-      return _then(_self.copyWith(unit_system: value));
-    });
-  }
+/// Create a copy of HassConfig
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? latitude = null,Object? longitude = null,Object? elevation = null,Object? radius = null,Object? unit_system = null,Object? location_name = null,Object? time_zone = null,Object? components = null,Object? config_dir = null,Object? allowlist_external_dirs = null,Object? allowlist_external_urls = null,Object? version = null,Object? config_source = null,Object? recovery_mode = null,Object? safe_mode = null,Object? state = null,Object? external_url = freezed,Object? internal_url = freezed,Object? whitelist_external_dirs = freezed,Object? currency = null,Object? country = freezed,Object? language = null,}) {
+  return _then(_self.copyWith(
+latitude: null == latitude ? _self.latitude : latitude // ignore: cast_nullable_to_non_nullable
+as double,longitude: null == longitude ? _self.longitude : longitude // ignore: cast_nullable_to_non_nullable
+as double,elevation: null == elevation ? _self.elevation : elevation // ignore: cast_nullable_to_non_nullable
+as double,radius: null == radius ? _self.radius : radius // ignore: cast_nullable_to_non_nullable
+as double,unit_system: null == unit_system ? _self.unit_system : unit_system // ignore: cast_nullable_to_non_nullable
+as UnitSystem,location_name: null == location_name ? _self.location_name : location_name // ignore: cast_nullable_to_non_nullable
+as String,time_zone: null == time_zone ? _self.time_zone : time_zone // ignore: cast_nullable_to_non_nullable
+as String,components: null == components ? _self.components : components // ignore: cast_nullable_to_non_nullable
+as List<String>,config_dir: null == config_dir ? _self.config_dir : config_dir // ignore: cast_nullable_to_non_nullable
+as String,allowlist_external_dirs: null == allowlist_external_dirs ? _self.allowlist_external_dirs : allowlist_external_dirs // ignore: cast_nullable_to_non_nullable
+as List<String>,allowlist_external_urls: null == allowlist_external_urls ? _self.allowlist_external_urls : allowlist_external_urls // ignore: cast_nullable_to_non_nullable
+as List<String>,version: null == version ? _self.version : version // ignore: cast_nullable_to_non_nullable
+as String,config_source: null == config_source ? _self.config_source : config_source // ignore: cast_nullable_to_non_nullable
+as String,recovery_mode: null == recovery_mode ? _self.recovery_mode : recovery_mode // ignore: cast_nullable_to_non_nullable
+as bool,safe_mode: null == safe_mode ? _self.safe_mode : safe_mode // ignore: cast_nullable_to_non_nullable
+as bool,state: null == state ? _self.state : state // ignore: cast_nullable_to_non_nullable
+as State,external_url: freezed == external_url ? _self.external_url : external_url // ignore: cast_nullable_to_non_nullable
+as String?,internal_url: freezed == internal_url ? _self.internal_url : internal_url // ignore: cast_nullable_to_non_nullable
+as String?,whitelist_external_dirs: freezed == whitelist_external_dirs ? _self.whitelist_external_dirs : whitelist_external_dirs // ignore: cast_nullable_to_non_nullable
+as List<String>?,currency: null == currency ? _self.currency : currency // ignore: cast_nullable_to_non_nullable
+as String,country: freezed == country ? _self.country : country // ignore: cast_nullable_to_non_nullable
+as String?,language: null == language ? _self.language : language // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
 }
+/// Create a copy of HassConfig
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UnitSystemCopyWith<$Res> get unit_system {
+  
+  return $UnitSystemCopyWith<$Res>(_self.unit_system, (value) {
+    return _then(_self.copyWith(unit_system: value));
+  });
+}
+}
+
 
 /// Adds pattern-matching-related methods to [HassConfig].
 extension HassConfigPatterns on HassConfig {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_HassConfig value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _HassConfig() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _HassConfig value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _HassConfig() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_HassConfig value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _HassConfig():
-        return $default(_that);
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _HassConfig value)  $default,){
+final _that = this;
+switch (_that) {
+case _HassConfig():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _HassConfig value)?  $default,){
+final _that = this;
+switch (_that) {
+case _HassConfig() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_HassConfig value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _HassConfig() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( double latitude,  double longitude,  double elevation,  double radius,  UnitSystem unit_system,  String location_name,  String time_zone,  List<String> components,  String config_dir,  List<String> allowlist_external_dirs,  List<String> allowlist_external_urls,  String version,  String config_source,  bool recovery_mode,  bool safe_mode,  State state,  String? external_url,  String? internal_url,  List<String>? whitelist_external_dirs,  String currency,  String? country,  String language)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _HassConfig() when $default != null:
+return $default(_that.latitude,_that.longitude,_that.elevation,_that.radius,_that.unit_system,_that.location_name,_that.time_zone,_that.components,_that.config_dir,_that.allowlist_external_dirs,_that.allowlist_external_urls,_that.version,_that.config_source,_that.recovery_mode,_that.safe_mode,_that.state,_that.external_url,_that.internal_url,_that.whitelist_external_dirs,_that.currency,_that.country,_that.language);case _:
+  return orElse();
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(
-            double latitude,
-            double longitude,
-            double elevation,
-            double radius,
-            UnitSystem unit_system,
-            String location_name,
-            String time_zone,
-            List<String> components,
-            String config_dir,
-            List<String> allowlist_external_dirs,
-            List<String> allowlist_external_urls,
-            String version,
-            String config_source,
-            bool recovery_mode,
-            bool safe_mode,
-            State state,
-            String? external_url,
-            String? internal_url,
-            List<String>? whitelist_external_dirs,
-            String currency,
-            String? country,
-            String language)?
-        $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _HassConfig() when $default != null:
-        return $default(
-            _that.latitude,
-            _that.longitude,
-            _that.elevation,
-            _that.radius,
-            _that.unit_system,
-            _that.location_name,
-            _that.time_zone,
-            _that.components,
-            _that.config_dir,
-            _that.allowlist_external_dirs,
-            _that.allowlist_external_urls,
-            _that.version,
-            _that.config_source,
-            _that.recovery_mode,
-            _that.safe_mode,
-            _that.state,
-            _that.external_url,
-            _that.internal_url,
-            _that.whitelist_external_dirs,
-            _that.currency,
-            _that.country,
-            _that.language);
-      case _:
-        return orElse();
-    }
-  }
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( double latitude,  double longitude,  double elevation,  double radius,  UnitSystem unit_system,  String location_name,  String time_zone,  List<String> components,  String config_dir,  List<String> allowlist_external_dirs,  List<String> allowlist_external_urls,  String version,  String config_source,  bool recovery_mode,  bool safe_mode,  State state,  String? external_url,  String? internal_url,  List<String>? whitelist_external_dirs,  String currency,  String? country,  String language)  $default,) {final _that = this;
+switch (_that) {
+case _HassConfig():
+return $default(_that.latitude,_that.longitude,_that.elevation,_that.radius,_that.unit_system,_that.location_name,_that.time_zone,_that.components,_that.config_dir,_that.allowlist_external_dirs,_that.allowlist_external_urls,_that.version,_that.config_source,_that.recovery_mode,_that.safe_mode,_that.state,_that.external_url,_that.internal_url,_that.whitelist_external_dirs,_that.currency,_that.country,_that.language);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(
-            double latitude,
-            double longitude,
-            double elevation,
-            double radius,
-            UnitSystem unit_system,
-            String location_name,
-            String time_zone,
-            List<String> components,
-            String config_dir,
-            List<String> allowlist_external_dirs,
-            List<String> allowlist_external_urls,
-            String version,
-            String config_source,
-            bool recovery_mode,
-            bool safe_mode,
-            State state,
-            String? external_url,
-            String? internal_url,
-            List<String>? whitelist_external_dirs,
-            String currency,
-            String? country,
-            String language)
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _HassConfig():
-        return $default(
-            _that.latitude,
-            _that.longitude,
-            _that.elevation,
-            _that.radius,
-            _that.unit_system,
-            _that.location_name,
-            _that.time_zone,
-            _that.components,
-            _that.config_dir,
-            _that.allowlist_external_dirs,
-            _that.allowlist_external_urls,
-            _that.version,
-            _that.config_source,
-            _that.recovery_mode,
-            _that.safe_mode,
-            _that.state,
-            _that.external_url,
-            _that.internal_url,
-            _that.whitelist_external_dirs,
-            _that.currency,
-            _that.country,
-            _that.language);
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( double latitude,  double longitude,  double elevation,  double radius,  UnitSystem unit_system,  String location_name,  String time_zone,  List<String> components,  String config_dir,  List<String> allowlist_external_dirs,  List<String> allowlist_external_urls,  String version,  String config_source,  bool recovery_mode,  bool safe_mode,  State state,  String? external_url,  String? internal_url,  List<String>? whitelist_external_dirs,  String currency,  String? country,  String language)?  $default,) {final _that = this;
+switch (_that) {
+case _HassConfig() when $default != null:
+return $default(_that.latitude,_that.longitude,_that.elevation,_that.radius,_that.unit_system,_that.location_name,_that.time_zone,_that.components,_that.config_dir,_that.allowlist_external_dirs,_that.allowlist_external_urls,_that.version,_that.config_source,_that.recovery_mode,_that.safe_mode,_that.state,_that.external_url,_that.internal_url,_that.whitelist_external_dirs,_that.currency,_that.country,_that.language);case _:
+  return null;
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(
-            double latitude,
-            double longitude,
-            double elevation,
-            double radius,
-            UnitSystem unit_system,
-            String location_name,
-            String time_zone,
-            List<String> components,
-            String config_dir,
-            List<String> allowlist_external_dirs,
-            List<String> allowlist_external_urls,
-            String version,
-            String config_source,
-            bool recovery_mode,
-            bool safe_mode,
-            State state,
-            String? external_url,
-            String? internal_url,
-            List<String>? whitelist_external_dirs,
-            String currency,
-            String? country,
-            String language)?
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _HassConfig() when $default != null:
-        return $default(
-            _that.latitude,
-            _that.longitude,
-            _that.elevation,
-            _that.radius,
-            _that.unit_system,
-            _that.location_name,
-            _that.time_zone,
-            _that.components,
-            _that.config_dir,
-            _that.allowlist_external_dirs,
-            _that.allowlist_external_urls,
-            _that.version,
-            _that.config_source,
-            _that.recovery_mode,
-            _that.safe_mode,
-            _that.state,
-            _that.external_url,
-            _that.internal_url,
-            _that.whitelist_external_dirs,
-            _that.currency,
-            _that.country,
-            _that.language);
-      case _:
-        return null;
-    }
-  }
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _HassConfig implements HassConfig {
-  const _HassConfig(
-      {required this.latitude,
-      required this.longitude,
-      required this.elevation,
-      required this.radius,
-      required this.unit_system,
-      required this.location_name,
-      required this.time_zone,
-      required final List<String> components,
-      required this.config_dir,
-      required final List<String> allowlist_external_dirs,
-      required final List<String> allowlist_external_urls,
-      required this.version,
-      required this.config_source,
-      required this.recovery_mode,
-      required this.safe_mode,
-      required this.state,
-      this.external_url,
-      this.internal_url,
-      final List<String>? whitelist_external_dirs,
-      required this.currency,
-      this.country,
-      required this.language})
-      : _components = components,
-        _allowlist_external_dirs = allowlist_external_dirs,
-        _allowlist_external_urls = allowlist_external_urls,
-        _whitelist_external_dirs = whitelist_external_dirs;
-  factory _HassConfig.fromJson(Map<String, dynamic> json) =>
-      _$HassConfigFromJson(json);
+  const _HassConfig({required this.latitude, required this.longitude, required this.elevation, required this.radius, required this.unit_system, required this.location_name, required this.time_zone, required final  List<String> components, required this.config_dir, required final  List<String> allowlist_external_dirs, required final  List<String> allowlist_external_urls, required this.version, required this.config_source, required this.recovery_mode, required this.safe_mode, required this.state, this.external_url, this.internal_url, final  List<String>? whitelist_external_dirs, required this.currency, this.country, required this.language}): _components = components,_allowlist_external_dirs = allowlist_external_dirs,_allowlist_external_urls = allowlist_external_urls,_whitelist_external_dirs = whitelist_external_dirs;
+  factory _HassConfig.fromJson(Map<String, dynamic> json) => _$HassConfigFromJson(json);
 
-  @override
-  final double latitude;
-  @override
-  final double longitude;
-  @override
-  final double elevation;
-  @override
-  final double radius;
-  @override
-  final UnitSystem unit_system;
-  @override
-  final String location_name;
-  @override
-  final String time_zone;
-  final List<String> _components;
-  @override
-  List<String> get components {
-    if (_components is EqualUnmodifiableListView) return _components;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_components);
-  }
+@override final  double latitude;
+@override final  double longitude;
+@override final  double elevation;
+@override final  double radius;
+@override final  UnitSystem unit_system;
+@override final  String location_name;
+@override final  String time_zone;
+ final  List<String> _components;
+@override List<String> get components {
+  if (_components is EqualUnmodifiableListView) return _components;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_components);
+}
 
-  @override
-  final String config_dir;
-  final List<String> _allowlist_external_dirs;
-  @override
-  List<String> get allowlist_external_dirs {
-    if (_allowlist_external_dirs is EqualUnmodifiableListView)
-      return _allowlist_external_dirs;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_allowlist_external_dirs);
-  }
+@override final  String config_dir;
+ final  List<String> _allowlist_external_dirs;
+@override List<String> get allowlist_external_dirs {
+  if (_allowlist_external_dirs is EqualUnmodifiableListView) return _allowlist_external_dirs;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_allowlist_external_dirs);
+}
 
-  final List<String> _allowlist_external_urls;
-  @override
-  List<String> get allowlist_external_urls {
-    if (_allowlist_external_urls is EqualUnmodifiableListView)
-      return _allowlist_external_urls;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_allowlist_external_urls);
-  }
+ final  List<String> _allowlist_external_urls;
+@override List<String> get allowlist_external_urls {
+  if (_allowlist_external_urls is EqualUnmodifiableListView) return _allowlist_external_urls;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_allowlist_external_urls);
+}
 
-  @override
-  final String version;
-  @override
-  final String config_source;
-  @override
-  final bool recovery_mode;
-  @override
-  final bool safe_mode;
+@override final  String version;
+@override final  String config_source;
+@override final  bool recovery_mode;
+@override final  bool safe_mode;
 // @StringEnum('NOT_RUNNING', 'STARTING', 'RUNNING', 'STOPPING', 'FINAL_WRITE')
-  @override
-  final State state;
-  @override
-  final String? external_url;
-  @override
-  final String? internal_url;
-  final List<String>? _whitelist_external_dirs;
-  @override
-  List<String>? get whitelist_external_dirs {
-    final value = _whitelist_external_dirs;
-    if (value == null) return null;
-    if (_whitelist_external_dirs is EqualUnmodifiableListView)
-      return _whitelist_external_dirs;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(value);
-  }
+@override final  State state;
+@override final  String? external_url;
+@override final  String? internal_url;
+ final  List<String>? _whitelist_external_dirs;
+@override List<String>? get whitelist_external_dirs {
+  final value = _whitelist_external_dirs;
+  if (value == null) return null;
+  if (_whitelist_external_dirs is EqualUnmodifiableListView) return _whitelist_external_dirs;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
+}
 
-  @override
-  final String currency;
-  @override
-  final String? country;
-  @override
-  final String language;
+@override final  String currency;
+@override final  String? country;
+@override final  String language;
 
-  /// Create a copy of HassConfig
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$HassConfigCopyWith<_HassConfig> get copyWith =>
-      __$HassConfigCopyWithImpl<_HassConfig>(this, _$identity);
+/// Create a copy of HassConfig
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$HassConfigCopyWith<_HassConfig> get copyWith => __$HassConfigCopyWithImpl<_HassConfig>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$HassConfigToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$HassConfigToJson(this, );
+}
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _HassConfig &&
-            (identical(other.latitude, latitude) ||
-                other.latitude == latitude) &&
-            (identical(other.longitude, longitude) ||
-                other.longitude == longitude) &&
-            (identical(other.elevation, elevation) ||
-                other.elevation == elevation) &&
-            (identical(other.radius, radius) || other.radius == radius) &&
-            (identical(other.unit_system, unit_system) ||
-                other.unit_system == unit_system) &&
-            (identical(other.location_name, location_name) ||
-                other.location_name == location_name) &&
-            (identical(other.time_zone, time_zone) ||
-                other.time_zone == time_zone) &&
-            const DeepCollectionEquality()
-                .equals(other._components, _components) &&
-            (identical(other.config_dir, config_dir) ||
-                other.config_dir == config_dir) &&
-            const DeepCollectionEquality().equals(
-                other._allowlist_external_dirs, _allowlist_external_dirs) &&
-            const DeepCollectionEquality().equals(
-                other._allowlist_external_urls, _allowlist_external_urls) &&
-            (identical(other.version, version) || other.version == version) &&
-            (identical(other.config_source, config_source) ||
-                other.config_source == config_source) &&
-            (identical(other.recovery_mode, recovery_mode) ||
-                other.recovery_mode == recovery_mode) &&
-            (identical(other.safe_mode, safe_mode) ||
-                other.safe_mode == safe_mode) &&
-            (identical(other.state, state) || other.state == state) &&
-            (identical(other.external_url, external_url) ||
-                other.external_url == external_url) &&
-            (identical(other.internal_url, internal_url) ||
-                other.internal_url == internal_url) &&
-            const DeepCollectionEquality().equals(
-                other._whitelist_external_dirs, _whitelist_external_dirs) &&
-            (identical(other.currency, currency) ||
-                other.currency == currency) &&
-            (identical(other.country, country) || other.country == country) &&
-            (identical(other.language, language) ||
-                other.language == language));
-  }
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _HassConfig&&(identical(other.latitude, latitude) || other.latitude == latitude)&&(identical(other.longitude, longitude) || other.longitude == longitude)&&(identical(other.elevation, elevation) || other.elevation == elevation)&&(identical(other.radius, radius) || other.radius == radius)&&(identical(other.unit_system, unit_system) || other.unit_system == unit_system)&&(identical(other.location_name, location_name) || other.location_name == location_name)&&(identical(other.time_zone, time_zone) || other.time_zone == time_zone)&&const DeepCollectionEquality().equals(other._components, _components)&&(identical(other.config_dir, config_dir) || other.config_dir == config_dir)&&const DeepCollectionEquality().equals(other._allowlist_external_dirs, _allowlist_external_dirs)&&const DeepCollectionEquality().equals(other._allowlist_external_urls, _allowlist_external_urls)&&(identical(other.version, version) || other.version == version)&&(identical(other.config_source, config_source) || other.config_source == config_source)&&(identical(other.recovery_mode, recovery_mode) || other.recovery_mode == recovery_mode)&&(identical(other.safe_mode, safe_mode) || other.safe_mode == safe_mode)&&(identical(other.state, state) || other.state == state)&&(identical(other.external_url, external_url) || other.external_url == external_url)&&(identical(other.internal_url, internal_url) || other.internal_url == internal_url)&&const DeepCollectionEquality().equals(other._whitelist_external_dirs, _whitelist_external_dirs)&&(identical(other.currency, currency) || other.currency == currency)&&(identical(other.country, country) || other.country == country)&&(identical(other.language, language) || other.language == language));
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hashAll([
-        runtimeType,
-        latitude,
-        longitude,
-        elevation,
-        radius,
-        unit_system,
-        location_name,
-        time_zone,
-        const DeepCollectionEquality().hash(_components),
-        config_dir,
-        const DeepCollectionEquality().hash(_allowlist_external_dirs),
-        const DeepCollectionEquality().hash(_allowlist_external_urls),
-        version,
-        config_source,
-        recovery_mode,
-        safe_mode,
-        state,
-        external_url,
-        internal_url,
-        const DeepCollectionEquality().hash(_whitelist_external_dirs),
-        currency,
-        country,
-        language
-      ]);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hashAll([runtimeType,latitude,longitude,elevation,radius,unit_system,location_name,time_zone,const DeepCollectionEquality().hash(_components),config_dir,const DeepCollectionEquality().hash(_allowlist_external_dirs),const DeepCollectionEquality().hash(_allowlist_external_urls),version,config_source,recovery_mode,safe_mode,state,external_url,internal_url,const DeepCollectionEquality().hash(_whitelist_external_dirs),currency,country,language]);
 
-  @override
-  String toString() {
-    return 'HassConfig(latitude: $latitude, longitude: $longitude, elevation: $elevation, radius: $radius, unit_system: $unit_system, location_name: $location_name, time_zone: $time_zone, components: $components, config_dir: $config_dir, allowlist_external_dirs: $allowlist_external_dirs, allowlist_external_urls: $allowlist_external_urls, version: $version, config_source: $config_source, recovery_mode: $recovery_mode, safe_mode: $safe_mode, state: $state, external_url: $external_url, internal_url: $internal_url, whitelist_external_dirs: $whitelist_external_dirs, currency: $currency, country: $country, language: $language)';
-  }
+@override
+String toString() {
+  return 'HassConfig(latitude: $latitude, longitude: $longitude, elevation: $elevation, radius: $radius, unit_system: $unit_system, location_name: $location_name, time_zone: $time_zone, components: $components, config_dir: $config_dir, allowlist_external_dirs: $allowlist_external_dirs, allowlist_external_urls: $allowlist_external_urls, version: $version, config_source: $config_source, recovery_mode: $recovery_mode, safe_mode: $safe_mode, state: $state, external_url: $external_url, internal_url: $internal_url, whitelist_external_dirs: $whitelist_external_dirs, currency: $currency, country: $country, language: $language)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class _$HassConfigCopyWith<$Res>
-    implements $HassConfigCopyWith<$Res> {
-  factory _$HassConfigCopyWith(
-          _HassConfig value, $Res Function(_HassConfig) _then) =
-      __$HassConfigCopyWithImpl;
-  @override
-  @useResult
-  $Res call(
-      {double latitude,
-      double longitude,
-      double elevation,
-      double radius,
-      UnitSystem unit_system,
-      String location_name,
-      String time_zone,
-      List<String> components,
-      String config_dir,
-      List<String> allowlist_external_dirs,
-      List<String> allowlist_external_urls,
-      String version,
-      String config_source,
-      bool recovery_mode,
-      bool safe_mode,
-      State state,
-      String? external_url,
-      String? internal_url,
-      List<String>? whitelist_external_dirs,
-      String currency,
-      String? country,
-      String language});
+abstract mixin class _$HassConfigCopyWith<$Res> implements $HassConfigCopyWith<$Res> {
+  factory _$HassConfigCopyWith(_HassConfig value, $Res Function(_HassConfig) _then) = __$HassConfigCopyWithImpl;
+@override @useResult
+$Res call({
+ double latitude, double longitude, double elevation, double radius, UnitSystem unit_system, String location_name, String time_zone, List<String> components, String config_dir, List<String> allowlist_external_dirs, List<String> allowlist_external_urls, String version, String config_source, bool recovery_mode, bool safe_mode, State state, String? external_url, String? internal_url, List<String>? whitelist_external_dirs, String currency, String? country, String language
+});
 
-  @override
-  $UnitSystemCopyWith<$Res> get unit_system;
+
+@override $UnitSystemCopyWith<$Res> get unit_system;
+
 }
-
 /// @nodoc
-class __$HassConfigCopyWithImpl<$Res> implements _$HassConfigCopyWith<$Res> {
+class __$HassConfigCopyWithImpl<$Res>
+    implements _$HassConfigCopyWith<$Res> {
   __$HassConfigCopyWithImpl(this._self, this._then);
 
   final _HassConfig _self;
   final $Res Function(_HassConfig) _then;
 
-  /// Create a copy of HassConfig
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? latitude = null,
-    Object? longitude = null,
-    Object? elevation = null,
-    Object? radius = null,
-    Object? unit_system = null,
-    Object? location_name = null,
-    Object? time_zone = null,
-    Object? components = null,
-    Object? config_dir = null,
-    Object? allowlist_external_dirs = null,
-    Object? allowlist_external_urls = null,
-    Object? version = null,
-    Object? config_source = null,
-    Object? recovery_mode = null,
-    Object? safe_mode = null,
-    Object? state = null,
-    Object? external_url = freezed,
-    Object? internal_url = freezed,
-    Object? whitelist_external_dirs = freezed,
-    Object? currency = null,
-    Object? country = freezed,
-    Object? language = null,
-  }) {
-    return _then(_HassConfig(
-      latitude: null == latitude
-          ? _self.latitude
-          : latitude // ignore: cast_nullable_to_non_nullable
-              as double,
-      longitude: null == longitude
-          ? _self.longitude
-          : longitude // ignore: cast_nullable_to_non_nullable
-              as double,
-      elevation: null == elevation
-          ? _self.elevation
-          : elevation // ignore: cast_nullable_to_non_nullable
-              as double,
-      radius: null == radius
-          ? _self.radius
-          : radius // ignore: cast_nullable_to_non_nullable
-              as double,
-      unit_system: null == unit_system
-          ? _self.unit_system
-          : unit_system // ignore: cast_nullable_to_non_nullable
-              as UnitSystem,
-      location_name: null == location_name
-          ? _self.location_name
-          : location_name // ignore: cast_nullable_to_non_nullable
-              as String,
-      time_zone: null == time_zone
-          ? _self.time_zone
-          : time_zone // ignore: cast_nullable_to_non_nullable
-              as String,
-      components: null == components
-          ? _self._components
-          : components // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-      config_dir: null == config_dir
-          ? _self.config_dir
-          : config_dir // ignore: cast_nullable_to_non_nullable
-              as String,
-      allowlist_external_dirs: null == allowlist_external_dirs
-          ? _self._allowlist_external_dirs
-          : allowlist_external_dirs // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-      allowlist_external_urls: null == allowlist_external_urls
-          ? _self._allowlist_external_urls
-          : allowlist_external_urls // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-      version: null == version
-          ? _self.version
-          : version // ignore: cast_nullable_to_non_nullable
-              as String,
-      config_source: null == config_source
-          ? _self.config_source
-          : config_source // ignore: cast_nullable_to_non_nullable
-              as String,
-      recovery_mode: null == recovery_mode
-          ? _self.recovery_mode
-          : recovery_mode // ignore: cast_nullable_to_non_nullable
-              as bool,
-      safe_mode: null == safe_mode
-          ? _self.safe_mode
-          : safe_mode // ignore: cast_nullable_to_non_nullable
-              as bool,
-      state: null == state
-          ? _self.state
-          : state // ignore: cast_nullable_to_non_nullable
-              as State,
-      external_url: freezed == external_url
-          ? _self.external_url
-          : external_url // ignore: cast_nullable_to_non_nullable
-              as String?,
-      internal_url: freezed == internal_url
-          ? _self.internal_url
-          : internal_url // ignore: cast_nullable_to_non_nullable
-              as String?,
-      whitelist_external_dirs: freezed == whitelist_external_dirs
-          ? _self._whitelist_external_dirs
-          : whitelist_external_dirs // ignore: cast_nullable_to_non_nullable
-              as List<String>?,
-      currency: null == currency
-          ? _self.currency
-          : currency // ignore: cast_nullable_to_non_nullable
-              as String,
-      country: freezed == country
-          ? _self.country
-          : country // ignore: cast_nullable_to_non_nullable
-              as String?,
-      language: null == language
-          ? _self.language
-          : language // ignore: cast_nullable_to_non_nullable
-              as String,
-    ));
-  }
-
-  /// Create a copy of HassConfig
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $UnitSystemCopyWith<$Res> get unit_system {
-    return $UnitSystemCopyWith<$Res>(_self.unit_system, (value) {
-      return _then(_self.copyWith(unit_system: value));
-    });
-  }
+/// Create a copy of HassConfig
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? latitude = null,Object? longitude = null,Object? elevation = null,Object? radius = null,Object? unit_system = null,Object? location_name = null,Object? time_zone = null,Object? components = null,Object? config_dir = null,Object? allowlist_external_dirs = null,Object? allowlist_external_urls = null,Object? version = null,Object? config_source = null,Object? recovery_mode = null,Object? safe_mode = null,Object? state = null,Object? external_url = freezed,Object? internal_url = freezed,Object? whitelist_external_dirs = freezed,Object? currency = null,Object? country = freezed,Object? language = null,}) {
+  return _then(_HassConfig(
+latitude: null == latitude ? _self.latitude : latitude // ignore: cast_nullable_to_non_nullable
+as double,longitude: null == longitude ? _self.longitude : longitude // ignore: cast_nullable_to_non_nullable
+as double,elevation: null == elevation ? _self.elevation : elevation // ignore: cast_nullable_to_non_nullable
+as double,radius: null == radius ? _self.radius : radius // ignore: cast_nullable_to_non_nullable
+as double,unit_system: null == unit_system ? _self.unit_system : unit_system // ignore: cast_nullable_to_non_nullable
+as UnitSystem,location_name: null == location_name ? _self.location_name : location_name // ignore: cast_nullable_to_non_nullable
+as String,time_zone: null == time_zone ? _self.time_zone : time_zone // ignore: cast_nullable_to_non_nullable
+as String,components: null == components ? _self._components : components // ignore: cast_nullable_to_non_nullable
+as List<String>,config_dir: null == config_dir ? _self.config_dir : config_dir // ignore: cast_nullable_to_non_nullable
+as String,allowlist_external_dirs: null == allowlist_external_dirs ? _self._allowlist_external_dirs : allowlist_external_dirs // ignore: cast_nullable_to_non_nullable
+as List<String>,allowlist_external_urls: null == allowlist_external_urls ? _self._allowlist_external_urls : allowlist_external_urls // ignore: cast_nullable_to_non_nullable
+as List<String>,version: null == version ? _self.version : version // ignore: cast_nullable_to_non_nullable
+as String,config_source: null == config_source ? _self.config_source : config_source // ignore: cast_nullable_to_non_nullable
+as String,recovery_mode: null == recovery_mode ? _self.recovery_mode : recovery_mode // ignore: cast_nullable_to_non_nullable
+as bool,safe_mode: null == safe_mode ? _self.safe_mode : safe_mode // ignore: cast_nullable_to_non_nullable
+as bool,state: null == state ? _self.state : state // ignore: cast_nullable_to_non_nullable
+as State,external_url: freezed == external_url ? _self.external_url : external_url // ignore: cast_nullable_to_non_nullable
+as String?,internal_url: freezed == internal_url ? _self.internal_url : internal_url // ignore: cast_nullable_to_non_nullable
+as String?,whitelist_external_dirs: freezed == whitelist_external_dirs ? _self._whitelist_external_dirs : whitelist_external_dirs // ignore: cast_nullable_to_non_nullable
+as List<String>?,currency: null == currency ? _self.currency : currency // ignore: cast_nullable_to_non_nullable
+as String,country: freezed == country ? _self.country : country // ignore: cast_nullable_to_non_nullable
+as String?,language: null == language ? _self.language : language // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
 }
+
+/// Create a copy of HassConfig
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UnitSystemCopyWith<$Res> get unit_system {
+  
+  return $UnitSystemCopyWith<$Res>(_self.unit_system, (value) {
+    return _then(_self.copyWith(unit_system: value));
+  });
+}
+}
+
 
 /// @nodoc
 mixin _$UnitSystem {
-  String get length;
-  String get mass;
-  String get volume;
-  String get temperature;
-  String get pressure;
-  String get wind_speed;
-  String get accumulated_precipitation;
 
-  /// Create a copy of UnitSystem
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $UnitSystemCopyWith<UnitSystem> get copyWith =>
-      _$UnitSystemCopyWithImpl<UnitSystem>(this as UnitSystem, _$identity);
+ String get length; String get mass; String get volume; String get temperature; String get pressure; String get wind_speed; String get accumulated_precipitation;
+/// Create a copy of UnitSystem
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$UnitSystemCopyWith<UnitSystem> get copyWith => _$UnitSystemCopyWithImpl<UnitSystem>(this as UnitSystem, _$identity);
 
   /// Serializes this UnitSystem to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is UnitSystem &&
-            (identical(other.length, length) || other.length == length) &&
-            (identical(other.mass, mass) || other.mass == mass) &&
-            (identical(other.volume, volume) || other.volume == volume) &&
-            (identical(other.temperature, temperature) ||
-                other.temperature == temperature) &&
-            (identical(other.pressure, pressure) ||
-                other.pressure == pressure) &&
-            (identical(other.wind_speed, wind_speed) ||
-                other.wind_speed == wind_speed) &&
-            (identical(other.accumulated_precipitation,
-                    accumulated_precipitation) ||
-                other.accumulated_precipitation == accumulated_precipitation));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(runtimeType, length, mass, volume,
-      temperature, pressure, wind_speed, accumulated_precipitation);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is UnitSystem&&(identical(other.length, length) || other.length == length)&&(identical(other.mass, mass) || other.mass == mass)&&(identical(other.volume, volume) || other.volume == volume)&&(identical(other.temperature, temperature) || other.temperature == temperature)&&(identical(other.pressure, pressure) || other.pressure == pressure)&&(identical(other.wind_speed, wind_speed) || other.wind_speed == wind_speed)&&(identical(other.accumulated_precipitation, accumulated_precipitation) || other.accumulated_precipitation == accumulated_precipitation));
+}
 
-  @override
-  String toString() {
-    return 'UnitSystem(length: $length, mass: $mass, volume: $volume, temperature: $temperature, pressure: $pressure, wind_speed: $wind_speed, accumulated_precipitation: $accumulated_precipitation)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,length,mass,volume,temperature,pressure,wind_speed,accumulated_precipitation);
+
+@override
+String toString() {
+  return 'UnitSystem(length: $length, mass: $mass, volume: $volume, temperature: $temperature, pressure: $pressure, wind_speed: $wind_speed, accumulated_precipitation: $accumulated_precipitation)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $UnitSystemCopyWith<$Res> {
-  factory $UnitSystemCopyWith(
-          UnitSystem value, $Res Function(UnitSystem) _then) =
-      _$UnitSystemCopyWithImpl;
-  @useResult
-  $Res call(
-      {String length,
-      String mass,
-      String volume,
-      String temperature,
-      String pressure,
-      String wind_speed,
-      String accumulated_precipitation});
-}
+abstract mixin class $UnitSystemCopyWith<$Res>  {
+  factory $UnitSystemCopyWith(UnitSystem value, $Res Function(UnitSystem) _then) = _$UnitSystemCopyWithImpl;
+@useResult
+$Res call({
+ String length, String mass, String volume, String temperature, String pressure, String wind_speed, String accumulated_precipitation
+});
 
+
+
+
+}
 /// @nodoc
-class _$UnitSystemCopyWithImpl<$Res> implements $UnitSystemCopyWith<$Res> {
+class _$UnitSystemCopyWithImpl<$Res>
+    implements $UnitSystemCopyWith<$Res> {
   _$UnitSystemCopyWithImpl(this._self, this._then);
 
   final UnitSystem _self;
   final $Res Function(UnitSystem) _then;
 
-  /// Create a copy of UnitSystem
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? length = null,
-    Object? mass = null,
-    Object? volume = null,
-    Object? temperature = null,
-    Object? pressure = null,
-    Object? wind_speed = null,
-    Object? accumulated_precipitation = null,
-  }) {
-    return _then(_self.copyWith(
-      length: null == length
-          ? _self.length
-          : length // ignore: cast_nullable_to_non_nullable
-              as String,
-      mass: null == mass
-          ? _self.mass
-          : mass // ignore: cast_nullable_to_non_nullable
-              as String,
-      volume: null == volume
-          ? _self.volume
-          : volume // ignore: cast_nullable_to_non_nullable
-              as String,
-      temperature: null == temperature
-          ? _self.temperature
-          : temperature // ignore: cast_nullable_to_non_nullable
-              as String,
-      pressure: null == pressure
-          ? _self.pressure
-          : pressure // ignore: cast_nullable_to_non_nullable
-              as String,
-      wind_speed: null == wind_speed
-          ? _self.wind_speed
-          : wind_speed // ignore: cast_nullable_to_non_nullable
-              as String,
-      accumulated_precipitation: null == accumulated_precipitation
-          ? _self.accumulated_precipitation
-          : accumulated_precipitation // ignore: cast_nullable_to_non_nullable
-              as String,
-    ));
-  }
+/// Create a copy of UnitSystem
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? length = null,Object? mass = null,Object? volume = null,Object? temperature = null,Object? pressure = null,Object? wind_speed = null,Object? accumulated_precipitation = null,}) {
+  return _then(_self.copyWith(
+length: null == length ? _self.length : length // ignore: cast_nullable_to_non_nullable
+as String,mass: null == mass ? _self.mass : mass // ignore: cast_nullable_to_non_nullable
+as String,volume: null == volume ? _self.volume : volume // ignore: cast_nullable_to_non_nullable
+as String,temperature: null == temperature ? _self.temperature : temperature // ignore: cast_nullable_to_non_nullable
+as String,pressure: null == pressure ? _self.pressure : pressure // ignore: cast_nullable_to_non_nullable
+as String,wind_speed: null == wind_speed ? _self.wind_speed : wind_speed // ignore: cast_nullable_to_non_nullable
+as String,accumulated_precipitation: null == accumulated_precipitation ? _self.accumulated_precipitation : accumulated_precipitation // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
 }
+
+}
+
 
 /// Adds pattern-matching-related methods to [UnitSystem].
 extension UnitSystemPatterns on UnitSystem {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_UnitSystem value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _UnitSystem() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _UnitSystem value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _UnitSystem() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_UnitSystem value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _UnitSystem():
-        return $default(_that);
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _UnitSystem value)  $default,){
+final _that = this;
+switch (_that) {
+case _UnitSystem():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _UnitSystem value)?  $default,){
+final _that = this;
+switch (_that) {
+case _UnitSystem() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_UnitSystem value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _UnitSystem() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String length,  String mass,  String volume,  String temperature,  String pressure,  String wind_speed,  String accumulated_precipitation)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _UnitSystem() when $default != null:
+return $default(_that.length,_that.mass,_that.volume,_that.temperature,_that.pressure,_that.wind_speed,_that.accumulated_precipitation);case _:
+  return orElse();
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(
-            String length,
-            String mass,
-            String volume,
-            String temperature,
-            String pressure,
-            String wind_speed,
-            String accumulated_precipitation)?
-        $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _UnitSystem() when $default != null:
-        return $default(
-            _that.length,
-            _that.mass,
-            _that.volume,
-            _that.temperature,
-            _that.pressure,
-            _that.wind_speed,
-            _that.accumulated_precipitation);
-      case _:
-        return orElse();
-    }
-  }
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String length,  String mass,  String volume,  String temperature,  String pressure,  String wind_speed,  String accumulated_precipitation)  $default,) {final _that = this;
+switch (_that) {
+case _UnitSystem():
+return $default(_that.length,_that.mass,_that.volume,_that.temperature,_that.pressure,_that.wind_speed,_that.accumulated_precipitation);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(
-            String length,
-            String mass,
-            String volume,
-            String temperature,
-            String pressure,
-            String wind_speed,
-            String accumulated_precipitation)
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _UnitSystem():
-        return $default(
-            _that.length,
-            _that.mass,
-            _that.volume,
-            _that.temperature,
-            _that.pressure,
-            _that.wind_speed,
-            _that.accumulated_precipitation);
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String length,  String mass,  String volume,  String temperature,  String pressure,  String wind_speed,  String accumulated_precipitation)?  $default,) {final _that = this;
+switch (_that) {
+case _UnitSystem() when $default != null:
+return $default(_that.length,_that.mass,_that.volume,_that.temperature,_that.pressure,_that.wind_speed,_that.accumulated_precipitation);case _:
+  return null;
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(
-            String length,
-            String mass,
-            String volume,
-            String temperature,
-            String pressure,
-            String wind_speed,
-            String accumulated_precipitation)?
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _UnitSystem() when $default != null:
-        return $default(
-            _that.length,
-            _that.mass,
-            _that.volume,
-            _that.temperature,
-            _that.pressure,
-            _that.wind_speed,
-            _that.accumulated_precipitation);
-      case _:
-        return null;
-    }
-  }
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _UnitSystem implements UnitSystem {
-  const _UnitSystem(
-      {required this.length,
-      required this.mass,
-      required this.volume,
-      required this.temperature,
-      required this.pressure,
-      required this.wind_speed,
-      required this.accumulated_precipitation});
-  factory _UnitSystem.fromJson(Map<String, dynamic> json) =>
-      _$UnitSystemFromJson(json);
+  const _UnitSystem({required this.length, required this.mass, required this.volume, required this.temperature, required this.pressure, required this.wind_speed, required this.accumulated_precipitation});
+  factory _UnitSystem.fromJson(Map<String, dynamic> json) => _$UnitSystemFromJson(json);
 
-  @override
-  final String length;
-  @override
-  final String mass;
-  @override
-  final String volume;
-  @override
-  final String temperature;
-  @override
-  final String pressure;
-  @override
-  final String wind_speed;
-  @override
-  final String accumulated_precipitation;
+@override final  String length;
+@override final  String mass;
+@override final  String volume;
+@override final  String temperature;
+@override final  String pressure;
+@override final  String wind_speed;
+@override final  String accumulated_precipitation;
 
-  /// Create a copy of UnitSystem
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$UnitSystemCopyWith<_UnitSystem> get copyWith =>
-      __$UnitSystemCopyWithImpl<_UnitSystem>(this, _$identity);
+/// Create a copy of UnitSystem
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$UnitSystemCopyWith<_UnitSystem> get copyWith => __$UnitSystemCopyWithImpl<_UnitSystem>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$UnitSystemToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$UnitSystemToJson(this, );
+}
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _UnitSystem &&
-            (identical(other.length, length) || other.length == length) &&
-            (identical(other.mass, mass) || other.mass == mass) &&
-            (identical(other.volume, volume) || other.volume == volume) &&
-            (identical(other.temperature, temperature) ||
-                other.temperature == temperature) &&
-            (identical(other.pressure, pressure) ||
-                other.pressure == pressure) &&
-            (identical(other.wind_speed, wind_speed) ||
-                other.wind_speed == wind_speed) &&
-            (identical(other.accumulated_precipitation,
-                    accumulated_precipitation) ||
-                other.accumulated_precipitation == accumulated_precipitation));
-  }
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _UnitSystem&&(identical(other.length, length) || other.length == length)&&(identical(other.mass, mass) || other.mass == mass)&&(identical(other.volume, volume) || other.volume == volume)&&(identical(other.temperature, temperature) || other.temperature == temperature)&&(identical(other.pressure, pressure) || other.pressure == pressure)&&(identical(other.wind_speed, wind_speed) || other.wind_speed == wind_speed)&&(identical(other.accumulated_precipitation, accumulated_precipitation) || other.accumulated_precipitation == accumulated_precipitation));
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(runtimeType, length, mass, volume,
-      temperature, pressure, wind_speed, accumulated_precipitation);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,length,mass,volume,temperature,pressure,wind_speed,accumulated_precipitation);
 
-  @override
-  String toString() {
-    return 'UnitSystem(length: $length, mass: $mass, volume: $volume, temperature: $temperature, pressure: $pressure, wind_speed: $wind_speed, accumulated_precipitation: $accumulated_precipitation)';
-  }
+@override
+String toString() {
+  return 'UnitSystem(length: $length, mass: $mass, volume: $volume, temperature: $temperature, pressure: $pressure, wind_speed: $wind_speed, accumulated_precipitation: $accumulated_precipitation)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class _$UnitSystemCopyWith<$Res>
-    implements $UnitSystemCopyWith<$Res> {
-  factory _$UnitSystemCopyWith(
-          _UnitSystem value, $Res Function(_UnitSystem) _then) =
-      __$UnitSystemCopyWithImpl;
-  @override
-  @useResult
-  $Res call(
-      {String length,
-      String mass,
-      String volume,
-      String temperature,
-      String pressure,
-      String wind_speed,
-      String accumulated_precipitation});
-}
+abstract mixin class _$UnitSystemCopyWith<$Res> implements $UnitSystemCopyWith<$Res> {
+  factory _$UnitSystemCopyWith(_UnitSystem value, $Res Function(_UnitSystem) _then) = __$UnitSystemCopyWithImpl;
+@override @useResult
+$Res call({
+ String length, String mass, String volume, String temperature, String pressure, String wind_speed, String accumulated_precipitation
+});
 
+
+
+
+}
 /// @nodoc
-class __$UnitSystemCopyWithImpl<$Res> implements _$UnitSystemCopyWith<$Res> {
+class __$UnitSystemCopyWithImpl<$Res>
+    implements _$UnitSystemCopyWith<$Res> {
   __$UnitSystemCopyWithImpl(this._self, this._then);
 
   final _UnitSystem _self;
   final $Res Function(_UnitSystem) _then;
 
-  /// Create a copy of UnitSystem
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? length = null,
-    Object? mass = null,
-    Object? volume = null,
-    Object? temperature = null,
-    Object? pressure = null,
-    Object? wind_speed = null,
-    Object? accumulated_precipitation = null,
-  }) {
-    return _then(_UnitSystem(
-      length: null == length
-          ? _self.length
-          : length // ignore: cast_nullable_to_non_nullable
-              as String,
-      mass: null == mass
-          ? _self.mass
-          : mass // ignore: cast_nullable_to_non_nullable
-              as String,
-      volume: null == volume
-          ? _self.volume
-          : volume // ignore: cast_nullable_to_non_nullable
-              as String,
-      temperature: null == temperature
-          ? _self.temperature
-          : temperature // ignore: cast_nullable_to_non_nullable
-              as String,
-      pressure: null == pressure
-          ? _self.pressure
-          : pressure // ignore: cast_nullable_to_non_nullable
-              as String,
-      wind_speed: null == wind_speed
-          ? _self.wind_speed
-          : wind_speed // ignore: cast_nullable_to_non_nullable
-              as String,
-      accumulated_precipitation: null == accumulated_precipitation
-          ? _self.accumulated_precipitation
-          : accumulated_precipitation // ignore: cast_nullable_to_non_nullable
-              as String,
-    ));
-  }
+/// Create a copy of UnitSystem
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? length = null,Object? mass = null,Object? volume = null,Object? temperature = null,Object? pressure = null,Object? wind_speed = null,Object? accumulated_precipitation = null,}) {
+  return _then(_UnitSystem(
+length: null == length ? _self.length : length // ignore: cast_nullable_to_non_nullable
+as String,mass: null == mass ? _self.mass : mass // ignore: cast_nullable_to_non_nullable
+as String,volume: null == volume ? _self.volume : volume // ignore: cast_nullable_to_non_nullable
+as String,temperature: null == temperature ? _self.temperature : temperature // ignore: cast_nullable_to_non_nullable
+as String,pressure: null == pressure ? _self.pressure : pressure // ignore: cast_nullable_to_non_nullable
+as String,wind_speed: null == wind_speed ? _self.wind_speed : wind_speed // ignore: cast_nullable_to_non_nullable
+as String,accumulated_precipitation: null == accumulated_precipitation ? _self.accumulated_precipitation : accumulated_precipitation // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
 }
 
 // dart format on

--- a/packages/home_assistant_websocket/lib/src/types/web_socket_response.freezed.dart
+++ b/packages/home_assistant_websocket/lib/src/types/web_socket_response.freezed.dart
@@ -11,65 +11,81 @@ part of 'web_socket_response.dart';
 
 // dart format off
 T _$identity<T>(T value) => value;
-WebSocketResponse _$WebSocketResponseFromJson(Map<String, dynamic> json) {
-  switch (json['runtimeType']) {
-    case 'pong':
-      return WebSocketPongResponse.fromJson(json);
-    case 'event':
-      return WebSocketEventResponse.fromJson(json);
-    case 'resultSuccess':
-      return WebSocketResultResponseSuccess.fromJson(json);
-    case 'resultError':
-      return WebSocketResultResponseError.fromJson(json);
-
-    default:
-      throw CheckedFromJsonException(json, 'runtimeType', 'WebSocketResponse',
-          'Invalid union type "${json['runtimeType']}"!');
-  }
+WebSocketResponse _$WebSocketResponseFromJson(
+  Map<String, dynamic> json
+) {
+        switch (json['runtimeType']) {
+                  case 'pong':
+          return WebSocketPongResponse.fromJson(
+            json
+          );
+                case 'event':
+          return WebSocketEventResponse.fromJson(
+            json
+          );
+                case 'resultSuccess':
+          return WebSocketResultResponseSuccess.fromJson(
+            json
+          );
+                case 'resultError':
+          return WebSocketResultResponseError.fromJson(
+            json
+          );
+        
+          default:
+            throw CheckedFromJsonException(
+  json,
+  'runtimeType',
+  'WebSocketResponse',
+  'Invalid union type "${json['runtimeType']}"!'
+);
+        }
+      
 }
 
 /// @nodoc
 mixin _$WebSocketResponse {
-  int get id;
 
-  /// Create a copy of WebSocketResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $WebSocketResponseCopyWith<WebSocketResponse> get copyWith =>
-      _$WebSocketResponseCopyWithImpl<WebSocketResponse>(
-          this as WebSocketResponse, _$identity);
+ int get id;
+/// Create a copy of WebSocketResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$WebSocketResponseCopyWith<WebSocketResponse> get copyWith => _$WebSocketResponseCopyWithImpl<WebSocketResponse>(this as WebSocketResponse, _$identity);
 
   /// Serializes this WebSocketResponse to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is WebSocketResponse &&
-            (identical(other.id, id) || other.id == id));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(runtimeType, id);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is WebSocketResponse&&(identical(other.id, id) || other.id == id));
+}
 
-  @override
-  String toString() {
-    return 'WebSocketResponse(id: $id)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id);
+
+@override
+String toString() {
+  return 'WebSocketResponse(id: $id)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $WebSocketResponseCopyWith<$Res> {
-  factory $WebSocketResponseCopyWith(
-          WebSocketResponse value, $Res Function(WebSocketResponse) _then) =
-      _$WebSocketResponseCopyWithImpl;
-  @useResult
-  $Res call({int id});
-}
+abstract mixin class $WebSocketResponseCopyWith<$Res>  {
+  factory $WebSocketResponseCopyWith(WebSocketResponse value, $Res Function(WebSocketResponse) _then) = _$WebSocketResponseCopyWithImpl;
+@useResult
+$Res call({
+ int id
+});
 
+
+
+
+}
 /// @nodoc
 class _$WebSocketResponseCopyWithImpl<$Res>
     implements $WebSocketResponseCopyWith<$Res> {
@@ -78,291 +94,213 @@ class _$WebSocketResponseCopyWithImpl<$Res>
   final WebSocketResponse _self;
   final $Res Function(WebSocketResponse) _then;
 
-  /// Create a copy of WebSocketResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? id = null,
-  }) {
-    return _then(_self.copyWith(
-      id: null == id
-          ? _self.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as int,
-    ));
-  }
+/// Create a copy of WebSocketResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
 }
+
+}
+
 
 /// Adds pattern-matching-related methods to [WebSocketResponse].
 extension WebSocketResponsePatterns on WebSocketResponse {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>({
-    TResult Function(WebSocketPongResponse value)? pong,
-    TResult Function(WebSocketEventResponse value)? event,
-    TResult Function(WebSocketResultResponseSuccess value)? resultSuccess,
-    TResult Function(WebSocketResultResponseError value)? resultError,
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case WebSocketPongResponse() when pong != null:
-        return pong(_that);
-      case WebSocketEventResponse() when event != null:
-        return event(_that);
-      case WebSocketResultResponseSuccess() when resultSuccess != null:
-        return resultSuccess(_that);
-      case WebSocketResultResponseError() when resultError != null:
-        return resultError(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( WebSocketPongResponse value)?  pong,TResult Function( WebSocketEventResponse value)?  event,TResult Function( WebSocketResultResponseSuccess value)?  resultSuccess,TResult Function( WebSocketResultResponseError value)?  resultError,required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case WebSocketPongResponse() when pong != null:
+return pong(_that);case WebSocketEventResponse() when event != null:
+return event(_that);case WebSocketResultResponseSuccess() when resultSuccess != null:
+return resultSuccess(_that);case WebSocketResultResponseError() when resultError != null:
+return resultError(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>({
-    required TResult Function(WebSocketPongResponse value) pong,
-    required TResult Function(WebSocketEventResponse value) event,
-    required TResult Function(WebSocketResultResponseSuccess value)
-        resultSuccess,
-    required TResult Function(WebSocketResultResponseError value) resultError,
-  }) {
-    final _that = this;
-    switch (_that) {
-      case WebSocketPongResponse():
-        return pong(_that);
-      case WebSocketEventResponse():
-        return event(_that);
-      case WebSocketResultResponseSuccess():
-        return resultSuccess(_that);
-      case WebSocketResultResponseError():
-        return resultError(_that);
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( WebSocketPongResponse value)  pong,required TResult Function( WebSocketEventResponse value)  event,required TResult Function( WebSocketResultResponseSuccess value)  resultSuccess,required TResult Function( WebSocketResultResponseError value)  resultError,}){
+final _that = this;
+switch (_that) {
+case WebSocketPongResponse():
+return pong(_that);case WebSocketEventResponse():
+return event(_that);case WebSocketResultResponseSuccess():
+return resultSuccess(_that);case WebSocketResultResponseError():
+return resultError(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( WebSocketPongResponse value)?  pong,TResult? Function( WebSocketEventResponse value)?  event,TResult? Function( WebSocketResultResponseSuccess value)?  resultSuccess,TResult? Function( WebSocketResultResponseError value)?  resultError,}){
+final _that = this;
+switch (_that) {
+case WebSocketPongResponse() when pong != null:
+return pong(_that);case WebSocketEventResponse() when event != null:
+return event(_that);case WebSocketResultResponseSuccess() when resultSuccess != null:
+return resultSuccess(_that);case WebSocketResultResponseError() when resultError != null:
+return resultError(_that);case _:
+  return null;
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(WebSocketPongResponse value)? pong,
-    TResult? Function(WebSocketEventResponse value)? event,
-    TResult? Function(WebSocketResultResponseSuccess value)? resultSuccess,
-    TResult? Function(WebSocketResultResponseError value)? resultError,
-  }) {
-    final _that = this;
-    switch (_that) {
-      case WebSocketPongResponse() when pong != null:
-        return pong(_that);
-      case WebSocketEventResponse() when event != null:
-        return event(_that);
-      case WebSocketResultResponseSuccess() when resultSuccess != null:
-        return resultSuccess(_that);
-      case WebSocketResultResponseError() when resultError != null:
-        return resultError(_that);
-      case _:
-        return null;
-    }
-  }
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( int id)?  pong,TResult Function( int id,  StatesUpdates event)?  event,TResult Function( int id,  dynamic result,  bool success)?  resultSuccess,TResult Function( int id,  bool success,  HassError error)?  resultError,required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case WebSocketPongResponse() when pong != null:
+return pong(_that.id);case WebSocketEventResponse() when event != null:
+return event(_that.id,_that.event);case WebSocketResultResponseSuccess() when resultSuccess != null:
+return resultSuccess(_that.id,_that.result,_that.success);case WebSocketResultResponseError() when resultError != null:
+return resultError(_that.id,_that.success,_that.error);case _:
+  return orElse();
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>({
-    TResult Function(int id)? pong,
-    TResult Function(int id, StatesUpdates event)? event,
-    TResult Function(int id, dynamic result, bool success)? resultSuccess,
-    TResult Function(int id, bool success, HassError error)? resultError,
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case WebSocketPongResponse() when pong != null:
-        return pong(_that.id);
-      case WebSocketEventResponse() when event != null:
-        return event(_that.id, _that.event);
-      case WebSocketResultResponseSuccess() when resultSuccess != null:
-        return resultSuccess(_that.id, _that.result, _that.success);
-      case WebSocketResultResponseError() when resultError != null:
-        return resultError(_that.id, _that.success, _that.error);
-      case _:
-        return orElse();
-    }
-  }
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( int id)  pong,required TResult Function( int id,  StatesUpdates event)  event,required TResult Function( int id,  dynamic result,  bool success)  resultSuccess,required TResult Function( int id,  bool success,  HassError error)  resultError,}) {final _that = this;
+switch (_that) {
+case WebSocketPongResponse():
+return pong(_that.id);case WebSocketEventResponse():
+return event(_that.id,_that.event);case WebSocketResultResponseSuccess():
+return resultSuccess(_that.id,_that.result,_that.success);case WebSocketResultResponseError():
+return resultError(_that.id,_that.success,_that.error);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>({
-    required TResult Function(int id) pong,
-    required TResult Function(int id, StatesUpdates event) event,
-    required TResult Function(int id, dynamic result, bool success)
-        resultSuccess,
-    required TResult Function(int id, bool success, HassError error)
-        resultError,
-  }) {
-    final _that = this;
-    switch (_that) {
-      case WebSocketPongResponse():
-        return pong(_that.id);
-      case WebSocketEventResponse():
-        return event(_that.id, _that.event);
-      case WebSocketResultResponseSuccess():
-        return resultSuccess(_that.id, _that.result, _that.success);
-      case WebSocketResultResponseError():
-        return resultError(_that.id, _that.success, _that.error);
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( int id)?  pong,TResult? Function( int id,  StatesUpdates event)?  event,TResult? Function( int id,  dynamic result,  bool success)?  resultSuccess,TResult? Function( int id,  bool success,  HassError error)?  resultError,}) {final _that = this;
+switch (_that) {
+case WebSocketPongResponse() when pong != null:
+return pong(_that.id);case WebSocketEventResponse() when event != null:
+return event(_that.id,_that.event);case WebSocketResultResponseSuccess() when resultSuccess != null:
+return resultSuccess(_that.id,_that.result,_that.success);case WebSocketResultResponseError() when resultError != null:
+return resultError(_that.id,_that.success,_that.error);case _:
+  return null;
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(int id)? pong,
-    TResult? Function(int id, StatesUpdates event)? event,
-    TResult? Function(int id, dynamic result, bool success)? resultSuccess,
-    TResult? Function(int id, bool success, HassError error)? resultError,
-  }) {
-    final _that = this;
-    switch (_that) {
-      case WebSocketPongResponse() when pong != null:
-        return pong(_that.id);
-      case WebSocketEventResponse() when event != null:
-        return event(_that.id, _that.event);
-      case WebSocketResultResponseSuccess() when resultSuccess != null:
-        return resultSuccess(_that.id, _that.result, _that.success);
-      case WebSocketResultResponseError() when resultError != null:
-        return resultError(_that.id, _that.success, _that.error);
-      case _:
-        return null;
-    }
-  }
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class WebSocketPongResponse implements WebSocketResponse {
-  const WebSocketPongResponse({required this.id, final String? $type})
-      : $type = $type ?? 'pong';
-  factory WebSocketPongResponse.fromJson(Map<String, dynamic> json) =>
-      _$WebSocketPongResponseFromJson(json);
+  const WebSocketPongResponse({required this.id, final  String? $type}): $type = $type ?? 'pong';
+  factory WebSocketPongResponse.fromJson(Map<String, dynamic> json) => _$WebSocketPongResponseFromJson(json);
 
-  @override
-  final int id;
+@override final  int id;
 
-  @JsonKey(name: 'runtimeType')
-  final String $type;
+@JsonKey(name: 'runtimeType')
+final String $type;
 
-  /// Create a copy of WebSocketResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $WebSocketPongResponseCopyWith<WebSocketPongResponse> get copyWith =>
-      _$WebSocketPongResponseCopyWithImpl<WebSocketPongResponse>(
-          this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$WebSocketPongResponseToJson(
-      this,
-    );
-  }
+/// Create a copy of WebSocketResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$WebSocketPongResponseCopyWith<WebSocketPongResponse> get copyWith => _$WebSocketPongResponseCopyWithImpl<WebSocketPongResponse>(this, _$identity);
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is WebSocketPongResponse &&
-            (identical(other.id, id) || other.id == id));
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$WebSocketPongResponseToJson(this, );
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(runtimeType, id);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is WebSocketPongResponse&&(identical(other.id, id) || other.id == id));
+}
 
-  @override
-  String toString() {
-    return 'WebSocketResponse.pong(id: $id)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id);
+
+@override
+String toString() {
+  return 'WebSocketResponse.pong(id: $id)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $WebSocketPongResponseCopyWith<$Res>
-    implements $WebSocketResponseCopyWith<$Res> {
-  factory $WebSocketPongResponseCopyWith(WebSocketPongResponse value,
-          $Res Function(WebSocketPongResponse) _then) =
-      _$WebSocketPongResponseCopyWithImpl;
-  @override
-  @useResult
-  $Res call({int id});
-}
+abstract mixin class $WebSocketPongResponseCopyWith<$Res> implements $WebSocketResponseCopyWith<$Res> {
+  factory $WebSocketPongResponseCopyWith(WebSocketPongResponse value, $Res Function(WebSocketPongResponse) _then) = _$WebSocketPongResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ int id
+});
 
+
+
+
+}
 /// @nodoc
 class _$WebSocketPongResponseCopyWithImpl<$Res>
     implements $WebSocketPongResponseCopyWith<$Res> {
@@ -371,86 +309,72 @@ class _$WebSocketPongResponseCopyWithImpl<$Res>
   final WebSocketPongResponse _self;
   final $Res Function(WebSocketPongResponse) _then;
 
-  /// Create a copy of WebSocketResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? id = null,
-  }) {
-    return _then(WebSocketPongResponse(
-      id: null == id
-          ? _self.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as int,
-    ));
-  }
+/// Create a copy of WebSocketResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,}) {
+  return _then(WebSocketPongResponse(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class WebSocketEventResponse implements WebSocketResponse {
-  const WebSocketEventResponse(
-      {required this.id, required this.event, final String? $type})
-      : $type = $type ?? 'event';
-  factory WebSocketEventResponse.fromJson(Map<String, dynamic> json) =>
-      _$WebSocketEventResponseFromJson(json);
+  const WebSocketEventResponse({required this.id, required this.event, final  String? $type}): $type = $type ?? 'event';
+  factory WebSocketEventResponse.fromJson(Map<String, dynamic> json) => _$WebSocketEventResponseFromJson(json);
 
-  @override
-  final int id;
-  final StatesUpdates event;
+@override final  int id;
+ final  StatesUpdates event;
 
-  @JsonKey(name: 'runtimeType')
-  final String $type;
+@JsonKey(name: 'runtimeType')
+final String $type;
 
-  /// Create a copy of WebSocketResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $WebSocketEventResponseCopyWith<WebSocketEventResponse> get copyWith =>
-      _$WebSocketEventResponseCopyWithImpl<WebSocketEventResponse>(
-          this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$WebSocketEventResponseToJson(
-      this,
-    );
-  }
+/// Create a copy of WebSocketResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$WebSocketEventResponseCopyWith<WebSocketEventResponse> get copyWith => _$WebSocketEventResponseCopyWithImpl<WebSocketEventResponse>(this, _$identity);
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is WebSocketEventResponse &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.event, event) || other.event == event));
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$WebSocketEventResponseToJson(this, );
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(runtimeType, id, event);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is WebSocketEventResponse&&(identical(other.id, id) || other.id == id)&&(identical(other.event, event) || other.event == event));
+}
 
-  @override
-  String toString() {
-    return 'WebSocketResponse.event(id: $id, event: $event)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,event);
+
+@override
+String toString() {
+  return 'WebSocketResponse.event(id: $id, event: $event)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $WebSocketEventResponseCopyWith<$Res>
-    implements $WebSocketResponseCopyWith<$Res> {
-  factory $WebSocketEventResponseCopyWith(WebSocketEventResponse value,
-          $Res Function(WebSocketEventResponse) _then) =
-      _$WebSocketEventResponseCopyWithImpl;
-  @override
-  @useResult
-  $Res call({int id, StatesUpdates event});
+abstract mixin class $WebSocketEventResponseCopyWith<$Res> implements $WebSocketResponseCopyWith<$Res> {
+  factory $WebSocketEventResponseCopyWith(WebSocketEventResponse value, $Res Function(WebSocketEventResponse) _then) = _$WebSocketEventResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ int id, StatesUpdates event
+});
 
-  $StatesUpdatesCopyWith<$Res> get event;
+
+$StatesUpdatesCopyWith<$Res> get event;
+
 }
-
 /// @nodoc
 class _$WebSocketEventResponseCopyWithImpl<$Res>
     implements $WebSocketEventResponseCopyWith<$Res> {
@@ -459,107 +383,83 @@ class _$WebSocketEventResponseCopyWithImpl<$Res>
   final WebSocketEventResponse _self;
   final $Res Function(WebSocketEventResponse) _then;
 
-  /// Create a copy of WebSocketResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? id = null,
-    Object? event = null,
-  }) {
-    return _then(WebSocketEventResponse(
-      id: null == id
-          ? _self.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as int,
-      event: null == event
-          ? _self.event
-          : event // ignore: cast_nullable_to_non_nullable
-              as StatesUpdates,
-    ));
-  }
+/// Create a copy of WebSocketResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? event = null,}) {
+  return _then(WebSocketEventResponse(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as int,event: null == event ? _self.event : event // ignore: cast_nullable_to_non_nullable
+as StatesUpdates,
+  ));
+}
 
-  /// Create a copy of WebSocketResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $StatesUpdatesCopyWith<$Res> get event {
-    return $StatesUpdatesCopyWith<$Res>(_self.event, (value) {
-      return _then(_self.copyWith(event: value));
-    });
-  }
+/// Create a copy of WebSocketResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$StatesUpdatesCopyWith<$Res> get event {
+  
+  return $StatesUpdatesCopyWith<$Res>(_self.event, (value) {
+    return _then(_self.copyWith(event: value));
+  });
+}
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class WebSocketResultResponseSuccess implements WebSocketResponse {
-  const WebSocketResultResponseSuccess(
-      {required this.id,
-      required this.result,
-      this.success = true,
-      final String? $type})
-      : $type = $type ?? 'resultSuccess';
-  factory WebSocketResultResponseSuccess.fromJson(Map<String, dynamic> json) =>
-      _$WebSocketResultResponseSuccessFromJson(json);
+  const WebSocketResultResponseSuccess({required this.id, required this.result, this.success = true, final  String? $type}): $type = $type ?? 'resultSuccess';
+  factory WebSocketResultResponseSuccess.fromJson(Map<String, dynamic> json) => _$WebSocketResultResponseSuccessFromJson(json);
 
-  @override
-  final int id;
-  final dynamic result;
-  @JsonKey()
-  final bool success;
+@override final  int id;
+ final  dynamic result;
+@JsonKey() final  bool success;
 
-  @JsonKey(name: 'runtimeType')
-  final String $type;
+@JsonKey(name: 'runtimeType')
+final String $type;
 
-  /// Create a copy of WebSocketResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $WebSocketResultResponseSuccessCopyWith<WebSocketResultResponseSuccess>
-      get copyWith => _$WebSocketResultResponseSuccessCopyWithImpl<
-          WebSocketResultResponseSuccess>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$WebSocketResultResponseSuccessToJson(
-      this,
-    );
-  }
+/// Create a copy of WebSocketResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$WebSocketResultResponseSuccessCopyWith<WebSocketResultResponseSuccess> get copyWith => _$WebSocketResultResponseSuccessCopyWithImpl<WebSocketResultResponseSuccess>(this, _$identity);
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is WebSocketResultResponseSuccess &&
-            (identical(other.id, id) || other.id == id) &&
-            const DeepCollectionEquality().equals(other.result, result) &&
-            (identical(other.success, success) || other.success == success));
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$WebSocketResultResponseSuccessToJson(this, );
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType, id, const DeepCollectionEquality().hash(result), success);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is WebSocketResultResponseSuccess&&(identical(other.id, id) || other.id == id)&&const DeepCollectionEquality().equals(other.result, result)&&(identical(other.success, success) || other.success == success));
+}
 
-  @override
-  String toString() {
-    return 'WebSocketResponse.resultSuccess(id: $id, result: $result, success: $success)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,const DeepCollectionEquality().hash(result),success);
+
+@override
+String toString() {
+  return 'WebSocketResponse.resultSuccess(id: $id, result: $result, success: $success)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $WebSocketResultResponseSuccessCopyWith<$Res>
-    implements $WebSocketResponseCopyWith<$Res> {
-  factory $WebSocketResultResponseSuccessCopyWith(
-          WebSocketResultResponseSuccess value,
-          $Res Function(WebSocketResultResponseSuccess) _then) =
-      _$WebSocketResultResponseSuccessCopyWithImpl;
-  @override
-  @useResult
-  $Res call({int id, dynamic result, bool success});
-}
+abstract mixin class $WebSocketResultResponseSuccessCopyWith<$Res> implements $WebSocketResponseCopyWith<$Res> {
+  factory $WebSocketResultResponseSuccessCopyWith(WebSocketResultResponseSuccess value, $Res Function(WebSocketResultResponseSuccess) _then) = _$WebSocketResultResponseSuccessCopyWithImpl;
+@override @useResult
+$Res call({
+ int id, dynamic result, bool success
+});
 
+
+
+
+}
 /// @nodoc
 class _$WebSocketResultResponseSuccessCopyWithImpl<$Res>
     implements $WebSocketResultResponseSuccessCopyWith<$Res> {
@@ -568,103 +468,75 @@ class _$WebSocketResultResponseSuccessCopyWithImpl<$Res>
   final WebSocketResultResponseSuccess _self;
   final $Res Function(WebSocketResultResponseSuccess) _then;
 
-  /// Create a copy of WebSocketResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? id = null,
-    Object? result = freezed,
-    Object? success = null,
-  }) {
-    return _then(WebSocketResultResponseSuccess(
-      id: null == id
-          ? _self.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as int,
-      result: freezed == result
-          ? _self.result
-          : result // ignore: cast_nullable_to_non_nullable
-              as dynamic,
-      success: null == success
-          ? _self.success
-          : success // ignore: cast_nullable_to_non_nullable
-              as bool,
-    ));
-  }
+/// Create a copy of WebSocketResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? result = freezed,Object? success = null,}) {
+  return _then(WebSocketResultResponseSuccess(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as int,result: freezed == result ? _self.result : result // ignore: cast_nullable_to_non_nullable
+as dynamic,success: null == success ? _self.success : success // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class WebSocketResultResponseError implements WebSocketResponse {
-  const WebSocketResultResponseError(
-      {required this.id,
-      this.success = false,
-      required this.error,
-      final String? $type})
-      : $type = $type ?? 'resultError';
-  factory WebSocketResultResponseError.fromJson(Map<String, dynamic> json) =>
-      _$WebSocketResultResponseErrorFromJson(json);
+  const WebSocketResultResponseError({required this.id, this.success = false, required this.error, final  String? $type}): $type = $type ?? 'resultError';
+  factory WebSocketResultResponseError.fromJson(Map<String, dynamic> json) => _$WebSocketResultResponseErrorFromJson(json);
 
-  @override
-  final int id;
-  @JsonKey()
-  final bool success;
-  final HassError error;
+@override final  int id;
+@JsonKey() final  bool success;
+ final  HassError error;
 
-  @JsonKey(name: 'runtimeType')
-  final String $type;
+@JsonKey(name: 'runtimeType')
+final String $type;
 
-  /// Create a copy of WebSocketResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $WebSocketResultResponseErrorCopyWith<WebSocketResultResponseError>
-      get copyWith => _$WebSocketResultResponseErrorCopyWithImpl<
-          WebSocketResultResponseError>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$WebSocketResultResponseErrorToJson(
-      this,
-    );
-  }
+/// Create a copy of WebSocketResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$WebSocketResultResponseErrorCopyWith<WebSocketResultResponseError> get copyWith => _$WebSocketResultResponseErrorCopyWithImpl<WebSocketResultResponseError>(this, _$identity);
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is WebSocketResultResponseError &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.success, success) || other.success == success) &&
-            (identical(other.error, error) || other.error == error));
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$WebSocketResultResponseErrorToJson(this, );
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(runtimeType, id, success, error);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is WebSocketResultResponseError&&(identical(other.id, id) || other.id == id)&&(identical(other.success, success) || other.success == success)&&(identical(other.error, error) || other.error == error));
+}
 
-  @override
-  String toString() {
-    return 'WebSocketResponse.resultError(id: $id, success: $success, error: $error)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,success,error);
+
+@override
+String toString() {
+  return 'WebSocketResponse.resultError(id: $id, success: $success, error: $error)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $WebSocketResultResponseErrorCopyWith<$Res>
-    implements $WebSocketResponseCopyWith<$Res> {
-  factory $WebSocketResultResponseErrorCopyWith(
-          WebSocketResultResponseError value,
-          $Res Function(WebSocketResultResponseError) _then) =
-      _$WebSocketResultResponseErrorCopyWithImpl;
-  @override
-  @useResult
-  $Res call({int id, bool success, HassError error});
+abstract mixin class $WebSocketResultResponseErrorCopyWith<$Res> implements $WebSocketResponseCopyWith<$Res> {
+  factory $WebSocketResultResponseErrorCopyWith(WebSocketResultResponseError value, $Res Function(WebSocketResultResponseError) _then) = _$WebSocketResultResponseErrorCopyWithImpl;
+@override @useResult
+$Res call({
+ int id, bool success, HassError error
+});
 
-  $HassErrorCopyWith<$Res> get error;
+
+$HassErrorCopyWith<$Res> get error;
+
 }
-
 /// @nodoc
 class _$WebSocketResultResponseErrorCopyWithImpl<$Res>
     implements $WebSocketResultResponseErrorCopyWith<$Res> {
@@ -673,40 +545,27 @@ class _$WebSocketResultResponseErrorCopyWithImpl<$Res>
   final WebSocketResultResponseError _self;
   final $Res Function(WebSocketResultResponseError) _then;
 
-  /// Create a copy of WebSocketResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? id = null,
-    Object? success = null,
-    Object? error = null,
-  }) {
-    return _then(WebSocketResultResponseError(
-      id: null == id
-          ? _self.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as int,
-      success: null == success
-          ? _self.success
-          : success // ignore: cast_nullable_to_non_nullable
-              as bool,
-      error: null == error
-          ? _self.error
-          : error // ignore: cast_nullable_to_non_nullable
-              as HassError,
-    ));
-  }
+/// Create a copy of WebSocketResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? success = null,Object? error = null,}) {
+  return _then(WebSocketResultResponseError(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as int,success: null == success ? _self.success : success // ignore: cast_nullable_to_non_nullable
+as bool,error: null == error ? _self.error : error // ignore: cast_nullable_to_non_nullable
+as HassError,
+  ));
+}
 
-  /// Create a copy of WebSocketResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $HassErrorCopyWith<$Res> get error {
-    return $HassErrorCopyWith<$Res>(_self.error, (value) {
-      return _then(_self.copyWith(error: value));
-    });
-  }
+/// Create a copy of WebSocketResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$HassErrorCopyWith<$Res> get error {
+  
+  return $HassErrorCopyWith<$Res>(_self.error, (value) {
+    return _then(_self.copyWith(error: value));
+  });
+}
 }
 
 // dart format on

--- a/packages/home_assistant_websocket/test/data_samples/get_services_response.json
+++ b/packages/home_assistant_websocket/test/data_samples/get_services_response.json
@@ -6,7 +6,6 @@
         "homeassistant": {
             "save_persistent_states": {
                 "name": "Save persistent states",
-                "description": "Saves the persistent states immediately. Maintains the normal periodic saving interval.",
                 "fields": {}
             },
             "turn_off": {

--- a/packages/home_assistant_websocket/test/data_samples/services_response_short.json
+++ b/packages/home_assistant_websocket/test/data_samples/services_response_short.json
@@ -37,7 +37,6 @@
                 "description": "Mark a notification read.",
                 "fields": {
                     "notification_id": {
-                        "description": "Target ID of the notification, which should be mark read. [Required]",
                         "example": 1234
                     }
                 }

--- a/packages/home_assistant_websocket/test/ha_connection_test.mocks.dart
+++ b/packages/home_assistant_websocket/test/ha_connection_test.mocks.dart
@@ -26,6 +26,7 @@ import 'package:mockito/src/dummies.dart' as _i6;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
+// ignore_for_file: invalid_use_of_internal_member
 
 class _FakeHaLogger_0 extends _i1.SmartFake implements _i2.HaLogger {
   _FakeHaLogger_0(Object parent, Invocation parentInvocation)
@@ -185,26 +186,26 @@ class MockStreamController<T> extends _i1.Mock
           as _i4.Future<dynamic>);
 
   @override
-  set onListen(void Function()? _onListen) => super.noSuchMethod(
-    Invocation.setter(#onListen, _onListen),
+  set onListen(void Function()? value) => super.noSuchMethod(
+    Invocation.setter(#onListen, value),
     returnValueForMissingStub: null,
   );
 
   @override
-  set onPause(void Function()? _onPause) => super.noSuchMethod(
-    Invocation.setter(#onPause, _onPause),
+  set onPause(void Function()? value) => super.noSuchMethod(
+    Invocation.setter(#onPause, value),
     returnValueForMissingStub: null,
   );
 
   @override
-  set onResume(void Function()? _onResume) => super.noSuchMethod(
-    Invocation.setter(#onResume, _onResume),
+  set onResume(void Function()? value) => super.noSuchMethod(
+    Invocation.setter(#onResume, value),
     returnValueForMissingStub: null,
   );
 
   @override
-  set onCancel(_i4.FutureOr<void> Function()? _onCancel) => super.noSuchMethod(
-    Invocation.setter(#onCancel, _onCancel),
+  set onCancel(_i4.FutureOr<void> Function()? value) => super.noSuchMethod(
+    Invocation.setter(#onCancel, value),
     returnValueForMissingStub: null,
   );
 

--- a/packages/home_assistant_websocket/test/send_ha_command_messages_test.mocks.dart
+++ b/packages/home_assistant_websocket/test/send_ha_command_messages_test.mocks.dart
@@ -26,6 +26,7 @@ import 'package:mockito/src/dummies.dart' as _i6;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
+// ignore_for_file: invalid_use_of_internal_member
 
 class _FakeHaLogger_0 extends _i1.SmartFake implements _i2.HaLogger {
   _FakeHaLogger_0(Object parent, Invocation parentInvocation)


### PR DESCRIPTION

This pull request primarily updates the handling of the `description` field in the `HassService` model to make it optional, ensuring the codebase can handle cases where this field is missing in service definitions. It also includes minor test data and mock file adjustments.

**HassService model improvements:**

* Changed the `description` field in the `HassService` class from required to optional (`String?`), allowing for services that do not provide a description. (`packages/home_assistant_websocket/lib/src/types/hass_service.dart`, `packages/home_assistant_websocket/lib/src/types/hass_service.g.dart`) [[1]](diffhunk://#diff-fb9b4b54e71eaea2549410f12f5cbf97f48a3c2bccfdd782a38e35e1206e58a1L69-R70) [[2]](diffhunk://#diff-f3f3299cc3749ddb6033ad50cf8908d563fe81884fe486b54a19df1d1b687f62L32-R32)

**Test data updates:**

* Updated sample JSON test data to remove or adjust descriptions, reflecting that the `description` field is now optional. (`packages/home_assistant_websocket/test/data_samples/get_services_response.json`, `packages/home_assistant_websocket/test/data_samples/services_response_short.json`) [[1]](diffhunk://#diff-52d90e51ab65d6bbaf20f5e97452141f7b384c673487d34ce24ce333be266dd6L9) [[2]](diffhunk://#diff-ee2941c96a1f1e4997dd8c24200eefcc1b8a3706f6ad8688227e30b7c3d7bd81L40)
